### PR TITLE
Load from ipynb and start sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,8 +245,10 @@ If you want custom keymaps, add `textobjects = { use_default_keybindings = false
 " Sync
 :JupyniumStartSync [filename / tab_index]
 :JupyniumStopSync
+:JupyniumLoadFromIpynbTab tab_index
+:JupyniumLoadFromIpynbTabAndStartSync tab_index
 
-" Notebook
+" Notebook (while syncing)
 :JupyniumSaveIpynb
 :JupyniumDownloadIpynb [filename]
 :JupyniumAutoDownloadIpynbToggle

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 selenium==4.7.2
-packaging==22.0
 coloredlogs==15.0.1
 verboselogs==1.7
 pynvim==0.4.3
 psutil==5.9.4
 persist-queue==0.8.0
+packaging==21.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,9 +19,9 @@ install_requires =
 	coloredlogs >= 15.0.0
 	verboselogs >= 1.7
 	selenium >= 4.7.2
-	packaging >= 22.0
 	psutil >= 5.9.4
 	persist-queue >= 0.8.0
+	packaging < 22.0
 python_requires = >=3.10
 package_dir =
     =src

--- a/src/jupynium/ipynb.py
+++ b/src/jupynium/ipynb.py
@@ -1,0 +1,41 @@
+import json
+
+
+def load_ipynb(ipynb_path):
+    with open(ipynb_path, "r") as f:
+        ipynb = json.load(f)
+    return ipynb
+
+
+def read_ipynb_texts(ipynb):
+    texts = []
+    cell_types = []
+    for cell in ipynb["cells"]:
+        cell_types.append(cell["cell_type"])
+        texts.append("".join(cell["source"]))
+    return cell_types, texts
+
+
+def ipynb2jupy(ipynb):
+    cell_types, texts = read_ipynb_texts(ipynb)
+    cell_types_previous = ["code"] + cell_types[:-1]
+
+    jupy: list[str] = []
+
+    for cell_type_previous, cell_type, text in zip(
+        cell_types_previous, cell_types, texts
+    ):
+        if cell_type == "code":
+            if cell_type_previous == "code":
+                jupy.append("# %%")
+            else:
+                jupy.append('%%"""')
+        else:
+            if cell_type_previous == "code":
+                jupy.append('"""%%')
+            else:
+                jupy.append("# %%%")
+
+        jupy.extend(text.split("\n"))
+
+    return jupy

--- a/src/jupynium/lua/commands.lua
+++ b/src/jupynium/lua/commands.lua
@@ -1,4 +1,10 @@
 vim.api.nvim_create_user_command("JupyniumStartSync", Jupynium_start_sync_cmd, { nargs = "?" })
+vim.api.nvim_create_user_command("JupyniumLoadFromIpynbTab", Jupynium_load_from_ipynb_tab_cmd, { nargs = 1 })
+vim.api.nvim_create_user_command(
+  "JupyniumLoadFromIpynbTabAndStartSync",
+  Jupynium_load_from_ipynb_tab_and_start_sync_cmd,
+  { nargs = 1 }
+)
 vim.api.nvim_create_user_command("JupyniumStopSync", "lua Jupynium_stop_sync()", {})
 vim.api.nvim_create_user_command("JupyniumExecuteSelectedCells", "lua Jupynium_execute_selected_cells()", {})
 vim.api.nvim_create_user_command("JupyniumClearSelectedCellsOutputs", "lua Jupynium_clear_selected_cells_outputs()", {})


### PR DESCRIPTION
This enables loading directly from opened ipynb file from the browser to nvim and start syncing.  

Adds 2 commands
```
:JupyniumLoadFromIpynbTab tab_index
:JupyniumLoadFromIpynbTabAndStartSync tab_index
```

Also this fixes system python startup issue with `LegacyVersion` from packaging.