### PR TITLE
Partial jupytext support

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ i.e. Any code below this line (and before the next separator) will be a code cel
 - `"""%%`: recommended
 - `'''%%`
 - `# %%%`
+- `# %% [md]`
+- `# %% [markdown]`
 
 **Explicitly specify the first cell separator to use it like a notebook.**
 

--- a/lua/jupynium/cells.lua
+++ b/lua/jupynium/cells.lua
@@ -12,6 +12,8 @@ local is_line_separator = function(row)
   if
     string_starts_with(line, "# %%")
     or string_starts_with(line, "# %%%")
+    or string_starts_with(line, "# %% [md]")
+    or string_starts_with(line, "# %% [markdown]")
     or string_starts_with(line, '"""%%')
     or string_starts_with(line, "'''%%")
     or string_starts_with(line, '%%"""')

--- a/src/jupynium/buffer.py
+++ b/src/jupynium/buffer.py
@@ -37,17 +37,19 @@ class JupyniumBuffer:
         for line in self.buf:
             if (
                 line.startswith("# %%%")
+                or line.startswith("# %% [md]")
+                or line.startswith("# %% [markdown]")
                 or line.startswith('"""%%')
                 or line.startswith("'''%%")
             ):
                 num_rows_per_cell.append(num_rows_this_cell)
                 num_rows_this_cell = 1
                 cell_types.append("markdown")
-            elif line.startswith("# %%"):
-                num_rows_per_cell.append(num_rows_this_cell)
-                num_rows_this_cell = 1
-                cell_types.append("code")
-            elif line.startswith('%%"""') or line.startswith("%%'''"):
+            elif (
+                line.startswith("# %%")
+                or line.startswith('%%"""')
+                or line.startswith("%%'''")
+            ):
                 num_rows_per_cell.append(num_rows_this_cell)
                 num_rows_this_cell = 1
                 cell_types.append("code")


### PR DESCRIPTION
I get that many people have been using the Jupytext format. This update supports Jupytext format partially (but not fully), by adding

- `# %% [md]`
- `# %% [markdown]`

as markdown cell separators.