### PR TITLE
Textobject move repeatable

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,8 @@ If you want custom keymaps, add `use_default_keybindings = false` and follow `M.
 ### Textobjects
 
 - `[j`, `]j`: go to previous / next cell separator
+  - Repeat with `;` and `,` if you have [nvim-treesitter-textobjects](https://github.com/nvim-treesitter/nvim-treesitter-textobjects).
+    Follow their instructions for keybindings for this.
 - `<space>j`: go to current cell separator
 - `vaj`,`vij`, `vaJ`, `viJ`: select current cell
   - `a`: include separator, `i`: exclude separator

--- a/lua/jupynium/textobj.lua
+++ b/lua/jupynium/textobj.lua
@@ -85,6 +85,12 @@ M.goto_next_cell_separator = function()
   vim.api.nvim_win_set_cursor(0, { row, 0 })
 end
 
+local status, repeat_move = pcall(require, "nvim-treesitter.textobjects.repeatable_move")
+if status then
+  M.goto_next_cell_separator, M.goto_previous_cell_separator =
+    repeat_move.make_repeatable_move_pair(M.goto_next_cell_separator, M.goto_previous_cell_separator)
+end
+
 M.goto_current_cell_separator = function()
   local row = cells.current_cell_separator()
   if row == nil then


### PR DESCRIPTION
Use `;` and `,` to repeat moving cells. Need [nvim-treesitter-textobjects](nvim-treesitter-textobjects) and you need to follow their instructions for key mappings.