### PR TITLE
fix windows #32

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ Click to see the setup defaults
 
 ```lua
 require("jupynium").setup({
-  -- python_host = "~/miniconda3/envs/jupynium/bin/python",     -- For Conda
-  -- python_host = [[~\AppData\Local\miniconda3\envs\jupynium\python.exe]], -- For Windows Conda
+  --- For Conda environment named "jupynium",
+  -- python_host = { "conda", "run", "--no-capture-output", "-n", "jupynium", "python" },
   python_host = vim.g.python3_host_prog or "python3",
 
   default_notebook_URL = "localhost:8888",
@@ -95,8 +95,9 @@ require("jupynium").setup({
   -- When you call :JupyniumStartAndAttachToServer and no notebook is open,
   -- then Jupynium will open the server for you using this command. (only when notebook_URL is localhost)
   jupyter_command = "jupyter",
-  -- jupyter_command = "~/miniconda3/bin/jupyter",      -- For Conda
-  -- jupyter_command = [[~\AppData\Local\miniconda3\Scripts\jupyter.exe]],  -- For Windows Conda
+  --- For Conda, maybe use base environment
+  --- then you can `conda install -n base nb_conda_kernels` to switch environment in Jupyter Notebook
+  -- jupyter_command = { "conda", "run", "--no-capture-output", "-n", "base", "jupyter" },
 
   -- Used when notebook is launched by using jupyter_command.
   -- If nil or "", it will open at the git directory of the current buffer,

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Install with vim-plug:
 
 ```vim
 Plug 'kiyoon/jupynium.nvim', { 'do': 'pip3 install --user .' }
-" Plug 'kiyoon/jupynium.nvim', { 'do': '~/miniconda3/envs/jupynium/bin/pip install .' }
+" Plug 'kiyoon/jupynium.nvim', { 'do': 'conda run --no-capture-output -n jupynium pip install .' }
 Plug 'rcarriga/nvim-notify'  " optional
 ```
 
@@ -60,7 +60,7 @@ Install with packer.nvim:
 
 ```lua
 use { "kiyoon/jupynium.nvim", run = "pip3 install --user ." }
--- use { "kiyoon/jupynium.nvim", run = "~/miniconda3/envs/jupynium/bin/pip install ." }
+-- use { "kiyoon/jupynium.nvim", run = "conda run --no-capture-output -n jupynium pip install ." }
 use { "rcarriga/nvim-notify" }  -- optional
 ```
 
@@ -70,7 +70,7 @@ Install with 💤lazy.nvim
   {
     "kiyoon/jupynium.nvim",
     build = "pip3 install --user .",
-    -- build = "~/miniconda3/envs/jupynium/bin/pip install .",
+    -- build = "conda run --no-capture-output -n jupynium pip install .",
     -- enabled = vim.fn.isdirectory(vim.fn.expand "~/miniconda3/envs/jupynium"),
   },
   "rcarriga/nvim-notify",  -- optional

--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ Click to see the setup defaults
 
 ```lua
 require("jupynium").setup({
-  -- Conda users:
-  -- python_host = "~/miniconda3/envs/jupynium/bin/python",
+  -- python_host = "~/miniconda3/envs/jupynium/bin/python",     -- For Conda
+  -- python_host = [[~\AppData\Local\miniconda3\envs\jupynium\python.exe]], -- For Windows Conda
   python_host = vim.g.python3_host_prog or "python3",
 
   default_notebook_URL = "localhost:8888",
@@ -95,7 +95,8 @@ require("jupynium").setup({
   -- When you call :JupyniumStartAndAttachToServer and no notebook is open,
   -- then Jupynium will open the server for you using this command. (only when notebook_URL is localhost)
   jupyter_command = "jupyter",
-  -- jupyter_command = "~/miniconda3/bin/jupyter",
+  -- jupyter_command = "~/miniconda3/bin/jupyter",      -- For Conda
+  -- jupyter_command = [[~\AppData\Local\miniconda3\Scripts\jupyter.exe]],  -- For Windows Conda
 
   -- Used when notebook is launched by using jupyter_command.
   -- If nil or "", it will open at the git directory of the current buffer,

--- a/lua/jupynium/options.lua
+++ b/lua/jupynium/options.lua
@@ -2,8 +2,8 @@ local M = {}
 
 M.opts = {}
 M.default_opts = {
-  -- Conda users:
-  -- python_host = "~/miniconda3/envs/jupynium/bin/python"
+  -- python_host = "~/miniconda3/envs/jupynium/bin/python",     -- For Conda
+  -- python_host = [[~\AppData\Local\miniconda3\envs\jupynium\python.exe]], -- For Windows Conda
   python_host = vim.g.python3_host_prog or "python3",
 
   default_notebook_URL = "localhost:8888",
@@ -12,7 +12,8 @@ M.default_opts = {
   -- When you call :JupyniumStartAndAttachToServer and no notebook is open,
   -- then Jupynium will open the server for you using this command. (only when notebook_URL is localhost)
   jupyter_command = "jupyter",
-  -- jupyter_command = "~/miniconda3/bin/jupyter",
+  -- jupyter_command = "~/miniconda3/bin/jupyter",      -- For Conda
+  -- jupyter_command = [[~\AppData\Local\miniconda3\Scripts\jupyter.exe]],  -- For Windows Conda
 
   -- Used when notebook is launched by using jupyter_command.
   -- If nil or "", it will open at the git directory of the current buffer,

--- a/lua/jupynium/options.lua
+++ b/lua/jupynium/options.lua
@@ -2,8 +2,8 @@ local M = {}
 
 M.opts = {}
 M.default_opts = {
-  -- python_host = "~/miniconda3/envs/jupynium/bin/python",     -- For Conda
-  -- python_host = [[~\AppData\Local\miniconda3\envs\jupynium\python.exe]], -- For Windows Conda
+  --- For Conda environment named "jupynium",
+  -- python_host = { "conda", "run", "--no-capture-output", "-n", "jupynium", "python" },
   python_host = vim.g.python3_host_prog or "python3",
 
   default_notebook_URL = "localhost:8888",
@@ -12,8 +12,9 @@ M.default_opts = {
   -- When you call :JupyniumStartAndAttachToServer and no notebook is open,
   -- then Jupynium will open the server for you using this command. (only when notebook_URL is localhost)
   jupyter_command = "jupyter",
-  -- jupyter_command = "~/miniconda3/bin/jupyter",      -- For Conda
-  -- jupyter_command = [[~\AppData\Local\miniconda3\Scripts\jupyter.exe]],  -- For Windows Conda
+  --- For Conda, maybe use base environment
+  --- then you can `conda install -n base nb_conda_kernels` to switch environment in Jupyter Notebook
+  -- jupyter_command = { "conda", "run", "--no-capture-output", "-n", "base", "jupyter" },
 
   -- Used when notebook is launched by using jupyter_command.
   -- If nil or "", it will open at the git directory of the current buffer,

--- a/lua/jupynium/server.lua
+++ b/lua/jupynium/server.lua
@@ -45,7 +45,12 @@ local function run_process(cmd, args)
       end
     else
       -- cmd.exe
-      cmd_str = [["]] .. vim.fn.expand(cmd) .. [["]]
+      -- Wrapping the command with double quotes means it's a file, not a command
+      -- So you need to check if you're running a command or a file.
+      cmd_str = vim.fn.expand(cmd)
+      if cmd_str:find " " ~= nil then
+        cmd_str = [["]] .. cmd_str .. [["]]
+      end
       for _, v in ipairs(args) do
         cmd_str = cmd_str .. [[ "]] .. v .. [["]]
       end
@@ -129,8 +134,9 @@ function M.register_autostart_autocmds(augroup, opts)
       local bufname = vim.api.nvim_buf_get_name(0)
       local bufnr = vim.api.nvim_get_current_buf()
       if not M.server_state.is_autostarted then
-        if opts.auto_start_server.enable
-            and utils.list_wildcard_match(bufname, opts.auto_start_server.file_pattern) ~= nil
+        if
+          opts.auto_start_server.enable
+          and utils.list_wildcard_match(bufname, opts.auto_start_server.file_pattern) ~= nil
         then
           vim.cmd [[JupyniumStartAndAttachToServer]]
           M.server_state.is_autostarted = true
@@ -138,8 +144,9 @@ function M.register_autostart_autocmds(augroup, opts)
       end
 
       if not M.server_state.is_autostarted and not M.server_state.is_autoattached then
-        if opts.auto_attach_to_server.enable
-            and utils.list_wildcard_match(bufname, opts.auto_attach_to_server.file_pattern) ~= nil
+        if
+          opts.auto_attach_to_server.enable
+          and utils.list_wildcard_match(bufname, opts.auto_attach_to_server.file_pattern) ~= nil
         then
           vim.cmd [[JupyniumAttachToServer]]
           M.server_state.is_autoattached = true

--- a/lua/jupynium/utils.lua
+++ b/lua/jupynium/utils.lua
@@ -44,4 +44,11 @@ function M.remove_duplicates(list)
   return res
 end
 
+function M.table_concat(t1, t2)
+  for i = 1, #t2 do
+    t1[#t1 + 1] = t2[i]
+  end
+  return t1
+end
+
 return M

--- a/src/jupynium/cmds/jupynium.py
+++ b/src/jupynium/cmds/jupynium.py
@@ -471,7 +471,6 @@ def main():
                     for listen_addr, rpcrequest_event in del_list:
                         nvims[listen_addr].close(driver)
                         if rpcrequest_event is not None:
-                            logger.info("event sent OK")
                             rpcrequest_event.send("OK")
                         del nvims[listen_addr]
 

--- a/src/jupynium/cmds/jupynium.py
+++ b/src/jupynium/cmds/jupynium.py
@@ -166,8 +166,7 @@ def get_parser():
         nargs="+",
         default=["jupyter"],
         help="Command to start Jupyter Notebook (but without notebook).\n"
-        "To use conda env, use `--jupyter_command ~/miniconda3/envs/env_name/bin/jupyter`.\n"
-        "Don't use `conda run ..` as it won't be killed afterwards (it opens another process with different pid so it's hard to keep track of it.)\n"
+        "To use conda env, use `--jupyter_command conda run ' --no-capture-output' ' -n' base jupyter`. Notice the space before the dash.\n"
         "It is used only when the --notebook_URL is localhost, and is not running.",
     )
     parser.add_argument(
@@ -355,7 +354,6 @@ def fallback_open_notebook_server(
     try:
         # strip commands because we need to escape args with dashes.
         # e.g. --jupyter_command conda run ' --no-capture-output' ' -n' env_name jupyter
-        # However, conda run will run process with another pid so it won't work well here. Don't use it.
 
         jupyter_command = [command.strip() for command in jupyter_command]
         jupyter_command[0] = os.path.expanduser(jupyter_command[0])

--- a/src/jupynium/lua/autocmd_vimleave.lua
+++ b/src/jupynium/lua/autocmd_vimleave.lua
@@ -2,7 +2,12 @@ local augroup = vim.api.nvim_create_augroup("jupynium_global", { clear = true })
 vim.api.nvim_create_autocmd({ "VimLeavePre" }, {
   -- Don't set the buffer. You can leave from another file.
   callback = function()
-    Jupynium_rpcrequest("VimLeavePre", 0)
+    if vim.fn.has "win32" == 1 then
+      -- On Windows, when the VimLeavePre event is triggered, the rpc is not able to respond to the request.
+      Jupynium_rpcnotify("VimLeavePre", 0)
+    else
+      Jupynium_rpcrequest("VimLeavePre", 0)
+    end
   end,
   group = augroup,
 })


### PR DESCRIPTION
Fixes #32 

Additionally:

1. Able to pass multiple arguments for the commands during setup. Example:  
```lua
require("jupynium").setup({
  python_host = { "conda", "run", "--no-capture-output", "-n", "base", "python" },
  jupyter_command = { "conda", "run", "--no-capture-output", "-n", "base", "jupyter" },
})
```