### PR TITLE
feat: option not to auto close tab and change BufWinLeave to BufUnload

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,9 @@ require("jupynium").setup({
   -- Related command :JupyniumDownloadIpynb
   auto_download_ipynb = true,
 
+  -- Automatically close tab that is in sync when you close buffer in vim.
+  auto_close_tab = true,
+
   -- Always scroll to the current cell.
   -- Related command :JupyniumScrollToCell
   autoscroll = {

--- a/lua/jupynium/options.lua
+++ b/lua/jupynium/options.lua
@@ -59,6 +59,9 @@ M.default_opts = {
   -- Related command :JupyniumDownloadIpynb
   auto_download_ipynb = true,
 
+  -- Automatically close tab that is in sync when you close buffer in vim.
+  auto_close_tab = true,
+
   -- Always scroll to the current cell.
   -- Related command :JupyniumScrollToCell
   autoscroll = {

--- a/lua/jupynium/server.lua
+++ b/lua/jupynium/server.lua
@@ -89,6 +89,10 @@ local function call_jupynium_cli(args, bg)
     error "Invalid python_host type."
   end
 
+  if not options.opts.auto_close_tab then
+    table.insert(args, "--no_auto_close_tab")
+  end
+
   if bg then
     run_process_bg(cmd, args)
   else

--- a/src/jupynium/cmds/jupynium.py
+++ b/src/jupynium/cmds/jupynium.py
@@ -176,6 +176,11 @@ def get_parser():
         "If None, open at a git dir of nvim's buffer path and still navigate to the buffer dir.\n"
         "(e.g. localhost:8888/tree/path/to/buffer)",
     )
+    parser.add_argument(
+        "--no_auto_close_tab",
+        action="store_true",
+        help="Disable auto closing of tabs when closing vim buffer that is in sync.",
+    )
 
     # parser.add_argument(
     #     "--browser",
@@ -244,7 +249,9 @@ def attach_new_neovim(
                 home_window = driver.current_window_handle
                 URL_to_home_windows[new_args.notebook_URL] = home_window
 
-            nvim_info = NvimInfo(nvim, home_window)
+            nvim_info = NvimInfo(
+                nvim, home_window, auto_close_tab=not new_args.no_auto_close_tab
+            )
             nvims[new_args.nvim_listen_addr] = nvim_info
         except Exception:
             logger.exception("Exception occurred while attaching a new nvim. Ignoring.")
@@ -456,7 +463,11 @@ def main():
 
             URL_to_home_windows = {args.notebook_URL: home_window}
             if args.nvim_listen_addr is not None and nvim is not None:
-                nvims = {args.nvim_listen_addr: NvimInfo(nvim, home_window)}
+                nvims = {
+                    args.nvim_listen_addr: NvimInfo(
+                        nvim, home_window, auto_close_tab=not args.no_auto_close_tab
+                    )
+                }
             else:
                 logger.info(
                     "No nvim attached. Waiting for nvim to attach. Run jupynium --nvim_listen_addr /tmp/example (use `:echo v:servername` of nvim)"

--- a/src/jupynium/events_control.py
+++ b/src/jupynium/events_control.py
@@ -535,10 +535,8 @@ def process_notification_event(
             if driver.current_window_handle == nvim_info.window_handles[bufnr]:
                 nvim_info.jupbufs[bufnr].full_sync_to_notebook(driver)
 
-        elif event[1] == "BufWinLeave":
-            logger.info("Buffer closed on nvim. Closing on Jupyter Notebook")
-            # driver.switch_to.window(nvim_info.window_handles[buf])
-            # driver.close()
+        elif event[1] == "BufUnload":
+            logger.info("Buffer unloaded on nvim. Closing on Jupyter Notebook")
             nvim_info.detach_buffer(bufnr, driver)
 
         elif event[1] == "stop_sync":

--- a/src/jupynium/lua/helpers.lua
+++ b/src/jupynium/lua/helpers.lua
@@ -237,11 +237,10 @@ function Jupynium_start_sync(bufnr, filename, ask)
     group = augroup,
   })
 
-  vim.api.nvim_create_autocmd({ "BufWinLeave" }, {
+  vim.api.nvim_create_autocmd({ "BufUnload" }, {
     buffer = bufnr,
     callback = function()
-      -- notify before detaching
-      Jupynium_rpcnotify("BufWinLeave", bufnr, true)
+      Jupynium_rpcnotify("BufUnload", bufnr, true)
       Jupynium_stop_sync(bufnr)
     end,
     group = augroup,

--- a/src/jupynium/nvim.py
+++ b/src/jupynium/nvim.py
@@ -18,6 +18,7 @@ class NvimInfo:
     home_window: str
     jupbufs: dict[int, JupyniumBuffer] = field(default_factory=dict)  # key = buffer ID
     window_handles: dict[int, str] = field(default_factory=dict)  # key = buffer ID
+    auto_close_tab: bool = True
 
     def attach_buffer(self, buf_id, content: list[str], window_handle):
         if buf_id in self.jupbufs or buf_id in self.window_handles:
@@ -30,10 +31,11 @@ class NvimInfo:
         if buf_id in self.jupbufs:
             del self.jupbufs[buf_id]
         if buf_id in self.window_handles:
-            if self.window_handles[buf_id] in driver.window_handles:
-                driver.switch_to.window(self.window_handles[buf_id])
-                driver.close()
-                driver.switch_to.window(self.home_window)
+            if self.auto_close_tab:
+                if self.window_handles[buf_id] in driver.window_handles:
+                    driver.switch_to.window(self.window_handles[buf_id])
+                    driver.close()
+                    driver.switch_to.window(self.home_window)
             del self.window_handles[buf_id]
 
     def check_window_alive_and_update(self, driver):


### PR DESCRIPTION
Fixes issue #34 

1. Now, by default the tab won't close (nor stop sync) when you `:q` or `:wq`. It will still run until `BufUnload`, which means you need to delete the buffer.

Tip: Use plugins like bufferline to see which buffer is loaded or not.

2. Add an option `auto_close_tab` to configure if you want the tab to close on stop sync. Default is `true`.