### PR TITLE
feat: smart select kernel when :JupyniumStartSync

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ The program is in the alpha stage. If it crashes it's likely that the whole brow
 > 🌽 How do I use different languages / kernels?
 
 Instead of `*.ju.py` if you make files named `*.ju.*` (e.g. `*.ju.r`) you will see all the keybindings and commands.  
-All the procedures should be the same, except that you would need to manually change the kernel from the browser.
+All the procedures should be the same.
 
 > The notebook content is not in sync with vim. How do I fix it?
 

--- a/src/jupynium/lua/helpers.lua
+++ b/src/jupynium/lua/helpers.lua
@@ -155,7 +155,11 @@ function Jupynium_start_sync_cmd(args)
   Jupynium_start_sync(buf, filename)
 end
 
-function Jupynium_start_sync(bufnr, filename, ask)
+---Start synchronising the buffer with the ipynb file
+---@param bufnr integer buffer number
+---@param ipynb_filename string name of the ipynb file
+---@param ask boolean whether to ask for confirmation
+function Jupynium_start_sync(bufnr, ipynb_filename, ask)
   if bufnr == nil or bufnr == 0 then
     bufnr = vim.api.nvim_get_current_buf()
   end
@@ -173,7 +177,12 @@ function Jupynium_start_sync(bufnr, filename, ask)
 
   local content = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
 
-  local response = Jupynium_rpcrequest("start_sync", bufnr, false, filename, ask, content)
+  -- Used for choosing the correct kernel
+  local buf_filetype = vim.api.nvim_buf_get_option(bufnr, "filetype")
+  local conda_env_path = vim.env.CONDA_PREFIX
+
+  local response =
+    Jupynium_rpcrequest("start_sync", bufnr, false, ipynb_filename, ask, content, buf_filetype, conda_env_path)
   if response ~= "OK" then
     Jupynium_notify.info { "Cancelling sync.." }
     return


### PR DESCRIPTION
When running `:JupyniumStartSync` it used to default to the python3 kernel. Now, it will try to select smartly.

1. Respect language. Check filetype of the buffer and choose the kernel with the same language.
2. Respect conda env path. Check `CONDA_PREFIX` environment variable to see if it matches the kernel's spec.