### PR TITLE
add geckodriver to requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The Jupynium server will receive events from Neovim, keep the copy of the buffer
 
 - 💻 Linux, macOS and Windows (CMD, PowerShell, WSL2)
 - 🦊 Firefox (Other browsers are not supported due to their limitation with Selenium)
+- 🦎 Mozilla geckodriver
 - ✌️ Neovim >= v0.8
 - 🐍 Python >= 3.7
 - 📔 Jupyter Notebook >= 6.2 (Doesn't support Jupyter Lab)


### PR DESCRIPTION
add geckodriver as an additional requirement. (could get it to run, tried all the methods to sync my browser with nvim turns out i didnt have geckodriver installed)