### PR TITLE
feat: kernel hover

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,8 +318,10 @@ i.e. Any code below this line (and before the next separator) will be a code cel
 
 - `<space>x`: Execute selected cells
 - `<space>c`: Clear selected cells
-- `<space>S`: Scroll to cell (if autoscroll is disabled)
 - `<PageUp>`, `<PageDown>`: Scroll notebook
+- `<space>js`: Scroll to cell (if autoscroll is disabled)
+- `<space>K`: Hover (inspect a variable)
+- `<space>jo`: Toggle output scroll (when output is long)
 
 If you want custom keymaps, add `use_default_keybindings = false` and follow `M.default_keybindings()` in [lua/jupynium/init.lua](lua/jupynium/init.lua).
 
@@ -328,7 +330,7 @@ If you want custom keymaps, add `use_default_keybindings = false` and follow `M.
 - `[j`, `]j`: go to previous / next cell separator
   - Repeat with `;` and `,` if you have [nvim-treesitter-textobjects](https://github.com/nvim-treesitter/nvim-treesitter-textobjects).
     Follow their instructions for keybindings for this.
-- `<space>j`: go to current cell separator
+- `<space>jj`: go to current cell separator
 - `vaj`,`vij`, `vaJ`, `viJ`: select current cell
   - `a`: include separator, `i`: exclude separator
   - `j`: exclude next separator, `J`: include next separator
@@ -340,6 +342,7 @@ If you want custom keymaps, add `textobjects = { use_default_keybindings = false
 ```vim
 " Server (only used when Neovim is local. See Command-Line Usage for remote neovim)
 :JupyniumStartAndAttachToServer [notebook_URL]
+:JupyniumStartAndAttachToServerInTerminal [notebook_URL]    " Useful for debugging
 :JupyniumAttachToServer [notebook_URL]
 
 " Sync
@@ -365,6 +368,7 @@ If you want custom keymaps, add `textobjects = { use_default_keybindings = false
 :JupyniumKernelRestart
 :JupyniumKernelInterrupt
 :JupyniumKernelSelect
+:JupyniumKernelHover      " See value like LSP hover
 
 " Highlight
 :JupyniumShortsightedToggle

--- a/lua/jupynium/init.lua
+++ b/lua/jupynium/init.lua
@@ -23,14 +23,20 @@ function M.default_keybindings(augroup)
         { buffer = buf_id, desc = "Jupynium clear selected cells" }
       )
       vim.keymap.set(
+        { "n" },
+        "<space>K",
+        "<cmd>JupyniumKernelHover<cr>",
+        { buffer = buf_id, desc = "Jupynium hover (inspect a variable)" }
+      )
+      vim.keymap.set(
         { "n", "x" },
-        "<space>S",
+        "<space>js",
         "<cmd>JupyniumScrollToCell<cr>",
         { buffer = buf_id, desc = "Jupynium scroll to cell" }
       )
       vim.keymap.set(
         { "n", "x" },
-        "<space>T",
+        "<space>jo",
         "<cmd>JupyniumToggleSelectedCellsOutputsScroll<cr>",
         { buffer = buf_id, desc = "Jupynium toggle selected cell output scroll" }
       )

--- a/lua/jupynium/textobj.lua
+++ b/lua/jupynium/textobj.lua
@@ -130,7 +130,7 @@ M.default_keybindings = function(augroup)
       )
       vim.keymap.set(
         { "n", "x", "o" },
-        "<space>j",
+        "<space>jj",
         "<cmd>lua require'jupynium.textobj'.goto_current_cell_separator()<cr>",
         { buffer = buf_id, desc = "Go to current Jupynium cell" }
       )

--- a/src/jupynium/buffer.py
+++ b/src/jupynium/buffer.py
@@ -100,6 +100,12 @@ class JupyniumBuffer:
                 if cell_types[-1] == "markdown (jupytext)":
                     self.buf[row] = self.buf[row][2:]
                 num_rows_this_cell += 1
+            elif line == '"""':
+                # Remove the comment for markdown cells
+                # Only activated if the cell separator is like Jupytext's
+                if cell_types[-1] == "markdown (jupytext)":
+                    self.buf[row] = ""
+                num_rows_this_cell += 1
             else:
                 num_rows_this_cell += 1
         num_rows_per_cell.append(num_rows_this_cell)

--- a/src/jupynium/cmds/jupynium.py
+++ b/src/jupynium/cmds/jupynium.py
@@ -20,7 +20,7 @@ import git
 import persistqueue
 import psutil
 import verboselogs
-from git.exc import InvalidGitRepositoryError
+from git.exc import InvalidGitRepositoryError, NoSuchPathError
 from persistqueue.exceptions import Empty
 from selenium import webdriver
 from selenium.common.exceptions import WebDriverException
@@ -342,6 +342,8 @@ def fallback_open_notebook_server(
                 rel_dir = os.path.relpath(buffer_dir, notebook_dir)
             except InvalidGitRepositoryError:
                 notebook_dir = buffer_dir
+            except NoSuchPathError:
+                notebook_dir = Path.cwd()
 
     notebook_token = generate_notebook_token()
     notebook_args = [

--- a/src/jupynium/events_control.py
+++ b/src/jupynium/events_control.py
@@ -30,6 +30,10 @@ get_cell_inputs_js_code = (
     resource_stream("jupynium", "js/get_cell_inputs.js").read().decode("utf-8")
 )
 
+kernel_inspect_js_code = (
+    resource_stream("jupynium", "js/kernel_inspect.js").read().decode("utf-8")
+)
+
 
 @dataclass
 class OnLinesArgs:
@@ -428,6 +432,14 @@ def process_request_event(nvim_info: NvimInfo, driver, event):
         logger.info(f"Current kernel name: {kernel_specs[0]}")
         logger.info(f"Kernel specs: {kernel_specs[1]}")
         event[3].send(kernel_specs)
+        return True, None
+
+    elif event[1] == "kernel_inspect":
+        (line, col) = event_args
+        driver.switch_to.window(nvim_info.window_handles[bufnr])
+        inspect_result = driver.execute_async_script(kernel_inspect_js_code, line, col)
+        logger.info(f"Kernel inspect: {inspect_result}")
+        event[3].send(inspect_result)
         return True, None
 
     elif event[1] == "execute_javascript":

--- a/src/jupynium/js/kernel_inspect.js
+++ b/src/jupynium/js/kernel_inspect.js
@@ -1,0 +1,20 @@
+// NOTE: use driver.execute_async_script() to run this script
+//
+// Get variable information from the kernel
+// Inspired by lkhphuc/jupyter-kernel.nvim
+// arguments: a line of code, cursor position
+
+// Make callback synchronous
+// https://stackoverflow.com/questions/46021802/python-selenium-execute-script-vs-execute-async
+
+var return_callback = arguments[arguments.length - 1] // this is used for returning the result.
+function inspectCallback(result) {
+  return_callback(result.content)
+}
+
+Jupyter.notebook.kernel.inspect(arguments[0], arguments[1], inspectCallback)
+
+// Only wait for 5 seconds
+setTimeout(function () {
+  return_callback(null)
+}, 5000)

--- a/src/jupynium/lua/commands.lua
+++ b/src/jupynium/lua/commands.lua
@@ -28,3 +28,4 @@ vim.api.nvim_create_user_command("JupyniumSelectKernel", "lua Jupynium_select_ke
 vim.api.nvim_create_user_command("JupyniumKernelRestart", "lua Jupynium_kernel_restart()", {})
 vim.api.nvim_create_user_command("JupyniumKernelInterrupt", "lua Jupynium_kernel_interrupt()", {})
 vim.api.nvim_create_user_command("JupyniumKernelSelect", "lua Jupynium_kernel_select()", {})
+vim.api.nvim_create_user_command("JupyniumKernelHover", "lua Jupynium_kernel_hover()", {})


### PR DESCRIPTION
## Features
- `:JupyniumKernelHover` (default binding `<space>K`): Inspect a variable from the jupyter kernel
  - Shout out to https://github.com/lkhphuc/jupyter-kernel.nvim for providing the code base
![Screenshot from 2023-02-26 17-38-27](https://user-images.githubusercontent.com/12980409/221427293-53ed063e-e532-4d30-b36c-240d92b5218c.png)
- `:JupyniumStartAndAttachToServerInTerminal`: Useful for debugging



## Fixes
- JupyniumKernelSelect crash when escape

## Breaking changes
- Some default keybindings have changed. The default bindings are provided mainly for new users, and they may change to more sensible ones in the future. You should disable default bindings if you don't want this change!