### PR TITLE
feat: highlight groups for Jupynium instead of linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,15 +186,6 @@ require("jupynium").setup({
 
   syntax_highlight = {
     enable = true,
-
-    highlight_groups = {
-      -- Set to false to disable each entry
-      code_cell_separator = "Folded",
-      markdown_cell_separator = "Pmenu",
-      code_cell_content = false,
-      markdown_cell_content = "CursorLine",
-      magic_command = "Keyword",
-    },
   },
 
   -- Dim all cells except the current one
@@ -202,6 +193,19 @@ require("jupynium").setup({
   shortsighted = false,
 })
 
+-- You can override highlighting groups.
+-- The default is different per colour scheme.
+-- This is a default when it's unknown. (may not be the best for all colour schemes)
+vim.cmd [[
+hi! link JupyniumCodeCellSeparator Folded
+hi! link JupyniumMarkdownCellSeparator Pmenu
+hi! link JupyniumMarkdownCellContent CursorLine
+hi! link JupyniumMagicCommand Keyword
+]]
+
+-- Currently only supports default settings for tokyonight.
+-- Submit your favourite settings on other colour schemes, and I can add defaults.
+-- Even better, you can submit a PR to that colour scheme to support Jupynium.
 ```
 
 </details>

--- a/lua/jupynium/highlighter.lua
+++ b/lua/jupynium/highlighter.lua
@@ -5,7 +5,6 @@ local M = {}
 
 M.options = {
   enable = true, -- separate from shortsighted.enable. Only for highlighting.
-  highlight_groups = {},
 
   shortsighted = {
     enable = true,
@@ -14,6 +13,75 @@ M.options = {
     },
   },
 }
+
+function M.setup(opts)
+  if opts.syntax_highlight.highlight_groups then
+    -- deprecated, use vim.cmd [[hi! link Jupynium... ...]]
+    vim.notify_once(
+      "Jupynium: Setting highlight groups via opts is deprecated. Set directly using e.g. vim.cmd[[hi! link JupyniumCodeCellSeparator Folded]]",
+      vim.log.levels.WARN
+    )
+    if opts.syntax_highlight.highlight_groups.code_cell_separator then
+      vim.cmd("hi! link JupyniumCodeCellSeparator " .. opts.syntax_highlight.highlight_groups.code_cell_separator)
+    end
+    if opts.syntax_highlight.highlight_groups.markdown_cell_separator then
+      vim.cmd(
+        "hi! link JupyniumMarkdownCellSeparator " .. opts.syntax_highlight.highlight_groups.markdown_cell_separator
+      )
+    end
+    if opts.syntax_highlight.highlight_groups.code_cell_content then
+      vim.cmd("hi! link JupyniumCodeCellContent " .. opts.syntax_highlight.highlight_groups.code_cell_content)
+    end
+    if opts.syntax_highlight.highlight_groups.markdown_cell_content then
+      vim.cmd("hi! link JupyniumMarkdownCellContent " .. opts.syntax_highlight.highlight_groups.markdown_cell_content)
+    end
+    if opts.syntax_highlight.highlight_groups.magic_command then
+      vim.cmd("hi! link JupyniumMagicCommand " .. opts.syntax_highlight.highlight_groups.magic_command)
+    end
+  end
+
+  -- If the colourscheme doesn't support Jupynium yet, link to some default highlight groups
+  -- Here we can define some default settings per colourscheme.
+  local colorscheme = vim.g.colors_name
+  if utils.string_begins_with(colorscheme, "tokyonight") then
+    colorscheme = "tokyonight"
+  end
+  local hlgroup
+  if vim.fn.hlexists "JupyniumCodeCellSeparator" == 0 then
+    vim.cmd [[hi! link JupyniumCodeCellSeparator Folded]]
+  end
+  if vim.fn.hlexists "JupyniumMarkdownCellSeparator" == 0 then
+    vim.cmd [[hi! link JupyniumMarkdownCellSeparator Pmenu]]
+  end
+  --- In most cases you don't want to link Code cell content to anything.
+  -- if vim.fn.hlexists "JupyniumCodeCellContent" == 0 then
+  --   vim.cmd [[hi! link JupyniumCodeCellContent Normal]]
+  -- end
+  if vim.fn.hlexists "JupyniumMarkdownCellContent" == 0 then
+    if colorscheme == "tokyonight" then
+      hlgroup = "Pmenu"
+    else
+      hlgroup = "CursorLine"
+    end
+    vim.cmd([[hi! link JupyniumMarkdownCellContent ]] .. hlgroup)
+  end
+  if vim.fn.hlexists "JupyniumMagicCommand" == 0 then
+    vim.cmd [[hi! link JupyniumMagicCommand Keyword]]
+  end
+
+  if opts.syntax_highlight.enable then
+    M.enable()
+  else
+    M.disable()
+  end
+
+  if opts.shortsighted then
+    M.shortsighted_enable()
+  else
+    M.shortsighted_disable()
+  end
+  M.add_commands()
+end
 
 function M.is_enabled()
   return M.options.enable or M.options.shortsighted.enable
@@ -35,13 +103,14 @@ local ns_shortsighted = vim.api.nvim_create_namespace "jupynium-shortsighted"
 ---@param buffer number
 ---@param line_number number 0-indexed
 ---@param hl_group string
-function M.set_line_hlgroup(buffer, namespace, line_number, hl_group)
+function M.set_line_hlgroup(buffer, namespace, line_number, hl_group, priority)
+  priority = priority or 99 -- Treesitter uses 100
   pcall(vim.api.nvim_buf_set_extmark, buffer, namespace, line_number, 0, {
     end_line = line_number + 1,
     end_col = 0,
     hl_group = hl_group,
     hl_eol = true,
-    priority = 10000,
+    priority = priority,
   })
 end
 
@@ -114,16 +183,18 @@ function M.update()
 
   if M.options.enable then
     for i, line_type in ipairs(line_types) do
+      -- priority 10000: above treesitter
+      -- priority 99: below treesitter (default)
       if line_type == "cell separator: code" then
-        M.set_line_hlgroup(0, ns_highlight, i - 1, M.options.highlight_groups.code_cell_separator)
+        M.set_line_hlgroup(0, ns_highlight, i - 1, "JupyniumCodeCellSeparator", 10000)
       elseif utils.string_begins_with(line_type, "cell separator: markdown") then
-        M.set_line_hlgroup(0, ns_highlight, i - 1, M.options.highlight_groups.markdown_cell_separator)
+        M.set_line_hlgroup(0, ns_highlight, i - 1, "JupyniumMarkdownCellSeparator", 10000)
       elseif utils.string_begins_with(line_type, "cell content: code") then
-        M.set_line_hlgroup(0, ns_highlight, i - 1, M.options.highlight_groups.code_cell_content)
+        M.set_line_hlgroup(0, ns_highlight, i - 1, "JupyniumCodeCellContent")
       elseif utils.string_begins_with(line_type, "cell content: markdown") then
-        M.set_line_hlgroup(0, ns_highlight, i - 1, M.options.highlight_groups.markdown_cell_content)
+        M.set_line_hlgroup(0, ns_highlight, i - 1, "JupyniumMarkdownCellContent")
       elseif line_type == "magic command" then
-        M.set_line_hlgroup(0, ns_highlight, i - 1, M.options.highlight_groups.magic_command)
+        M.set_line_hlgroup(0, ns_highlight, i - 1, "JupyniumMagicCommand", 10000)
       end
     end
   end
@@ -141,7 +212,7 @@ function M.update()
       -- Exclude current cell separator
       for i = 1, current_row - 1 do
         if line_types[i] ~= "empty" then
-          M.set_line_hlgroup(0, ns_shortsighted, i - 1, M.options.shortsighted.highlight_groups.dim)
+          M.set_line_hlgroup(0, ns_shortsighted, i - 1, M.options.shortsighted.highlight_groups.dim, 10000)
         end
       end
     end
@@ -150,7 +221,7 @@ function M.update()
       -- Dim below cell range
       for j = next_row, end_of_file do
         if not line_types[j] ~= "empty" then
-          M.set_line_hlgroup(0, ns_shortsighted, j - 1, M.options.shortsighted.highlight_groups.dim)
+          M.set_line_hlgroup(0, ns_shortsighted, j - 1, M.options.shortsighted.highlight_groups.dim, 10000)
         end
       end
     end

--- a/lua/jupynium/init.lua
+++ b/lua/jupynium/init.lua
@@ -83,19 +83,7 @@ function M.setup(opts)
     textobj.default_keybindings(augroup)
   end
 
-  highlighter.options.highlight_groups = options.opts.syntax_highlight.highlight_groups
-  if options.opts.syntax_highlight.enable then
-    highlighter.enable()
-  else
-    highlighter.disable()
-  end
-
-  if options.opts.shortsighted then
-    highlighter.shortsighted_enable()
-  else
-    highlighter.shortsighted_disable()
-  end
-  highlighter.add_commands()
+  highlighter.setup(options.opts)
 
   vim.g.__jupynium_setup_completed = true
 end

--- a/lua/jupynium/options.lua
+++ b/lua/jupynium/options.lua
@@ -86,15 +86,6 @@ M.default_opts = {
 
   syntax_highlight = {
     enable = true,
-
-    highlight_groups = {
-      -- Set to false to disable each entry
-      code_cell_separator = "Folded",
-      markdown_cell_separator = "Pmenu",
-      code_cell_content = false,
-      markdown_cell_content = "CursorLine",
-      magic_command = "Keyword",
-    },
   },
 
   -- Dim all cells except the current one


### PR DESCRIPTION
Added highlight groups so they can be configured outside of the jupynium `setup()`.  
Using the setup method is now deprecated.

You can link like this. The following is the default when the colour scheme is unknown:

```lua
vim.cmd [[
hi! link JupyniumCodeCellSeparator Folded
hi! link JupyniumMarkdownCellSeparator Pmenu
hi! link JupyniumMarkdownCellContent CursorLine
hi! link JupyniumMagicCommand Keyword
]]
```

Default settings for tokyonight colourscheme have been added. 
(`hi! link JupyniumMarkdownCellContent Pmenu`)