### PR TITLE
Handle more than one "window" (tab) when starting browser

### DIFF
--- a/src/jupynium/cmds/jupynium.py
+++ b/src/jupynium/cmds/jupynium.py
@@ -222,6 +222,18 @@ def start_if_running_else_clear(args, q: persistqueue.UniqueQ):
     return None
 
 
+def number_of_windows_geq(num_windows: int):
+    """
+    An expectation for the number of windows to be greater than or equal to a certain value.
+    Slightly modified from EC.number_of_windows_to_be(num_windows).
+    """
+
+    def _predicate(driver: webdriver.Firefox):
+        return len(driver.window_handles) >= num_windows
+
+    return _predicate
+
+
 def attach_new_neovim(
     driver,
     new_args,
@@ -458,7 +470,7 @@ def main():
 
             # Wait for the notebook to load
             driver_wait = WebDriverWait(driver, 10)
-            driver_wait.until(EC.number_of_windows_to_be(1))
+            driver_wait.until(number_of_windows_geq(1))
             sele.wait_until_loaded(driver)
 
             home_window = driver.current_window_handle


### PR DESCRIPTION
This fixes #59 by recording the initial number of tabs opened and waiting until the number of tabs equals the initial number or the initial number + 1. This is more general behaviour which checked only for equality with 1, which meant that if a profile opened tab by default, or if an extension did so, there would be a timeout error. 

I tested on the following case:
- A "blank" profile that has a single tab and keeps a single tab (default expected behaviour)
- A profile with an extension that opens a second tab as newtab (so initial number is 2)
- A profile with a pinned tab that opens automatically (so that initial number is 2, or 3 if an extension opens a new tab)

EDIT: Added cases I tested.