### PR TITLE
Check for matching executable in environment path when no `conda_env_name` metadata (enables `venv` default kernels)

### DIFF
--- a/src/jupynium/events_control.py
+++ b/src/jupynium/events_control.py
@@ -326,7 +326,9 @@ def start_sync_with_filename(
         nvim_info.jupbufs[bufnr].full_sync_to_notebook(driver)
 
 
-def choose_default_kernel(driver, page_type: str, buf_filetype, conda_env_path, virtual_env_path):
+def choose_default_kernel(
+    driver, page_type: str, buf_filetype, conda_env_path, virtual_env_path
+):
     """
     Choose kernel based on buffer's filetype and conda env
     """
@@ -424,7 +426,14 @@ def process_request_event(nvim_info: NvimInfo, driver, event):
     event_args = event[2][1:]
 
     if event[1] == "start_sync":
-        ipynb_filename, ask, content, buf_filetype, conda_env_path, virtual_env_path = event_args
+        (
+            ipynb_filename,
+            ask,
+            content,
+            buf_filetype,
+            conda_env_path,
+            virtual_env_path,
+        ) = event_args
         ipynb_filename: str
         ipynb_filename = ipynb_filename.strip()
 

--- a/src/jupynium/events_control.py
+++ b/src/jupynium/events_control.py
@@ -357,7 +357,8 @@ def choose_default_kernel(driver, page_type: str, buf_filetype, conda_env_path, 
         for kernel_name in valid_kernel_names:
             try:
                 kernel_exec_path = kernel_specs[kernel_name]["spec"]["argv"][0]
-                env_exec_path = os.path.join(env_path, "bin", kernel_specs[kernel_name]["spec"]["language"])
+                exec_name = os.path.basename(kernel_exec_path)
+                env_exec_path = os.path.join(env_path, "bin", exec_name)
                 if kernel_exec_path == env_exec_path:
                     return kernel_name
             except KeyError:

--- a/src/jupynium/lua/helpers.lua
+++ b/src/jupynium/lua/helpers.lua
@@ -204,9 +204,10 @@ function Jupynium_start_sync(bufnr, ipynb_filename, ask)
   -- Used for choosing the correct kernel
   local buf_filetype = vim.api.nvim_buf_get_option(bufnr, "filetype")
   local conda_env_path = vim.env.CONDA_PREFIX
+  local virtual_env_path = vim.env.VIRTUAL_ENV
 
   local response =
-    Jupynium_rpcrequest("start_sync", bufnr, false, ipynb_filename, ask, content, buf_filetype, conda_env_path)
+    Jupynium_rpcrequest("start_sync", bufnr, false, ipynb_filename, ask, content, buf_filetype, conda_env_path, virtual_env_path)
   if response ~= "OK" then
     Jupynium_notify.info { "Cancelling sync.." }
     return

--- a/src/jupynium/lua/helpers.lua
+++ b/src/jupynium/lua/helpers.lua
@@ -206,8 +206,17 @@ function Jupynium_start_sync(bufnr, ipynb_filename, ask)
   local conda_env_path = vim.env.CONDA_PREFIX
   local virtual_env_path = vim.env.VIRTUAL_ENV
 
-  local response =
-    Jupynium_rpcrequest("start_sync", bufnr, false, ipynb_filename, ask, content, buf_filetype, conda_env_path, virtual_env_path)
+  local response = Jupynium_rpcrequest(
+    "start_sync",
+    bufnr,
+    false,
+    ipynb_filename,
+    ask,
+    content,
+    buf_filetype,
+    conda_env_path,
+    virtual_env_path
+  )
   if response ~= "OK" then
     Jupynium_notify.info { "Cancelling sync.." }
     return

--- a/src/jupynium/lua/helpers.lua
+++ b/src/jupynium/lua/helpers.lua
@@ -203,8 +203,7 @@ function Jupynium_start_sync(bufnr, ipynb_filename, ask)
 
   -- Used for choosing the correct kernel
   local buf_filetype = vim.api.nvim_buf_get_option(bufnr, "filetype")
-  local conda_env_path = vim.env.CONDA_PREFIX
-  local virtual_env_path = vim.env.VIRTUAL_ENV
+  local conda_or_venv_path = vim.env.CONDA_PREFIX or vim.env.VIRTUAL_ENV
 
   local response = Jupynium_rpcrequest(
     "start_sync",
@@ -214,8 +213,7 @@ function Jupynium_start_sync(bufnr, ipynb_filename, ask)
     ask,
     content,
     buf_filetype,
-    conda_env_path,
-    virtual_env_path
+    conda_or_venv_path
   )
   if response ~= "OK" then
     Jupynium_notify.info { "Cancelling sync.." }
@@ -274,8 +272,8 @@ function Jupynium_start_sync(bufnr, ipynb_filename, ask)
         local visual_start_row = vim.fn.getpos("v")[2] - 1
         Jupynium_rpcnotify("visual_enter", bufnr, true, cursor_pos_row, visual_start_row)
       elseif
-        (old_mode == "v" or old_mode == "V" or old_mode == "\x16")
-        and (new_mode ~= "v" and new_mode ~= "V" and new_mode ~= "\x16")
+          (old_mode == "v" or old_mode == "V" or old_mode == "\x16")
+          and (new_mode ~= "v" and new_mode ~= "V" and new_mode ~= "\x16")
       then
         local winid = vim.call("bufwinid", bufnr)
         local cursor_pos = vim.api.nvim_win_get_cursor(winid)
@@ -627,11 +625,11 @@ function Jupynium_kernel_hover(bufnr)
     -- 2. %[%d+; is the ANSI escape code for a digit color
     -- and so on
     out = inspect.data["text/plain"]
-      :gsub("\x1b%[%d+;%d+;%d+;%d+;%d+m", "")
-      :gsub("\x1b%[%d+;%d+;%d+;%d+m", "")
-      :gsub("\x1b%[%d+;%d+;%d+m", "")
-      :gsub("\x1b%[%d+;%d+m", "")
-      :gsub("\x1b%[%d+m", "")
+        :gsub("\x1b%[%d+;%d+;%d+;%d+;%d+m", "")
+        :gsub("\x1b%[%d+;%d+;%d+;%d+m", "")
+        :gsub("\x1b%[%d+;%d+;%d+m", "")
+        :gsub("\x1b%[%d+;%d+m", "")
+        :gsub("\x1b%[%d+m", "")
     -- The following regex convert ansi code for tab
     -- out = out:gsub("\x1b%[H", "\t")
   end

--- a/src/jupynium/lua/helpers.lua
+++ b/src/jupynium/lua/helpers.lua
@@ -205,16 +205,8 @@ function Jupynium_start_sync(bufnr, ipynb_filename, ask)
   local buf_filetype = vim.api.nvim_buf_get_option(bufnr, "filetype")
   local conda_or_venv_path = vim.env.CONDA_PREFIX or vim.env.VIRTUAL_ENV
 
-  local response = Jupynium_rpcrequest(
-    "start_sync",
-    bufnr,
-    false,
-    ipynb_filename,
-    ask,
-    content,
-    buf_filetype,
-    conda_or_venv_path
-  )
+  local response =
+    Jupynium_rpcrequest("start_sync", bufnr, false, ipynb_filename, ask, content, buf_filetype, conda_or_venv_path)
   if response ~= "OK" then
     Jupynium_notify.info { "Cancelling sync.." }
     return
@@ -272,8 +264,8 @@ function Jupynium_start_sync(bufnr, ipynb_filename, ask)
         local visual_start_row = vim.fn.getpos("v")[2] - 1
         Jupynium_rpcnotify("visual_enter", bufnr, true, cursor_pos_row, visual_start_row)
       elseif
-          (old_mode == "v" or old_mode == "V" or old_mode == "\x16")
-          and (new_mode ~= "v" and new_mode ~= "V" and new_mode ~= "\x16")
+        (old_mode == "v" or old_mode == "V" or old_mode == "\x16")
+        and (new_mode ~= "v" and new_mode ~= "V" and new_mode ~= "\x16")
       then
         local winid = vim.call("bufwinid", bufnr)
         local cursor_pos = vim.api.nvim_win_get_cursor(winid)
@@ -625,11 +617,11 @@ function Jupynium_kernel_hover(bufnr)
     -- 2. %[%d+; is the ANSI escape code for a digit color
     -- and so on
     out = inspect.data["text/plain"]
-        :gsub("\x1b%[%d+;%d+;%d+;%d+;%d+m", "")
-        :gsub("\x1b%[%d+;%d+;%d+;%d+m", "")
-        :gsub("\x1b%[%d+;%d+;%d+m", "")
-        :gsub("\x1b%[%d+;%d+m", "")
-        :gsub("\x1b%[%d+m", "")
+      :gsub("\x1b%[%d+;%d+;%d+;%d+;%d+m", "")
+      :gsub("\x1b%[%d+;%d+;%d+;%d+m", "")
+      :gsub("\x1b%[%d+;%d+;%d+m", "")
+      :gsub("\x1b%[%d+;%d+m", "")
+      :gsub("\x1b%[%d+m", "")
     -- The following regex convert ansi code for tab
     -- out = out:gsub("\x1b%[H", "\t")
   end


### PR DESCRIPTION
This closes #66. It works as follows:

1. Add `virtual_env_path` variable in lua and pass it to the RPC request alongside `conda_env_path`
2. If `conda_env_path` is not None, this environment is used and `virtual_env_path` is ignored
3. If `conda_env_path` is not None, the default check based on `conda_env_name` is done first.
4. If no match based on name, a cross-match is done between the executable in kernel spec and a matching executable in the environment base directory
5. If `conda_env_path` is None, step 4 is executed for `virtual_env_path`