### PR TITLE
feat: post evaluate cell text (jupytext percent format with python multi-line string)

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ For example:
 
 ### Setup a Jupynium file
 
-Jupynium uses a unique file format (see the `Jupynium file format` section below). This `.ju.py` file is what you will primarily be interacting with, rather than the `.ipynb` file directly. The contents of the Jupynium file are synced to the browser notebook where it can be viewed in real-time. If you want to keep a copy of the notebook, it can be downloaded as an `.ipynb` file later.
+Jupynium uses a Jupytext's percent format (see the `Jupynium file format` section below). This Jupytext file named `.ju.py` is what you will primarily be interacting with, rather than the `.ipynb` file directly. The contents of the Jupynium file are synced to the browser notebook where it can be viewed in real-time. If you want to keep a copy of the notebook, it can be downloaded as an `.ipynb` file later.
 
 First, it's recommended to set a password on your notebook (rather than using tokens):
 
@@ -289,8 +289,10 @@ There are currently 2 ways of converting an existing `.ipynb` file to a Jupynium
 **Option 1**: Use an included command line tool:
 
 ```bash
-ipynb2jupy [-h] [--stdout] file.ipynb [file.ju.py]
+ipynb2jupytext [-h] [--stdout] file.ipynb [file.ju.py]
 ```
+
+If you're already familiar with Jupytext, feel free to use it instead.
 
 **Option 2**: This method requires that you have already connected to the Jupynium server:
 
@@ -334,22 +336,43 @@ If you have `auto_attach_to_server = false` during setup, you need to run `:Jupy
 
 ## 📝 Jupynium file format (.ju.py or .ju.\*)
 
-The file format is designed to be LSP friendly even with markdown code injected into it. The markdown cells will be part of a Python string: `"""%%` ... `%%"""`.
+The Jupynium file format follows Jupytext's percent format. In order for Jupynium to detect the files, name them as `*.ju.py` or specify `jupynium_file_pattern` in `require("jupynium").setup()`.
 
-**Code cell separators:**  
-i.e. Any code below this line (and before the next separator) will be a code cell.
+**Code cell:**  
+Any code below this line (and before the next separator) will be the content of a code cell.
 
-- `# %%`: recommended
-- `%%"""`: use when you want to close a markdown cell
-- `%%'''`
+- `# %%`
 
-**Markdown cell separators:**
+**Magic commands**
 
-- `"""%%`: recommended
-- `'''%%`
-- `# %%%`
+- `# %time` becomes `%time` in notebook.
+- If you want to really comment out magic commands, make the line not start with `# %`. For example,
+  - `## %time`
+  - `#%time`
+
+**Markdown cell:**
+Any code below this line will be markdown cell content.  
+
 - `# %% [md]`
 - `# %% [markdown]`
+
+In Python, the recommended way is to wrap the whole cell content as a multi-line string.
+
+```python
+# %% [md]
+"""
+# This is a markdown heading
+This is markdown content
+"""
+```
+
+In other languages like R, you'll need to comment every line.
+
+```r
+# %% [md]
+# # This is a markdown heading
+# This is markdown content
+```
 
 **Explicitly specify the first cell separator to use it like a notebook.**
 
@@ -358,12 +381,6 @@ i.e. Any code below this line (and before the next separator) will be a code cel
 - If there is no cell, it works as a markdown preview mode.
   - It will still open ipynb file but will one have one markdown cell.
 
-**Magic commands**
-
-- `# %time` becomes `%time` in notebook.
-- If you want to really comment out magic commands, make the line not start with `# %`. For example,
-  - `## %time`
-  - `#%time`
 
 ## ⌨️ Keybindings
 

--- a/after/queries/python/highlights.scm
+++ b/after/queries/python/highlights.scm
@@ -1,0 +1,19 @@
+; extends
+
+(expression_statement
+ ((string) @_var @variable)
+ (#match? @_var "^[\"']{3}[%]{2}.*[%]{2}[\"']{3}$")
+)
+
+; it can be # %% [markdown] or # %% [md]
+((
+  (comment) @_mdcomment
+  . (expression_statement 
+      (string (string_content) @variable)))
+  (#lua-match? @_mdcomment "^# %%%% %[markdown%]"))
+
+((
+  (comment) @_mdcomment
+  . (expression_statement 
+      (string (string_content) @variable)))
+  (#lua-match? @_mdcomment "^# %%%% %[md%]"))

--- a/after/queries/python/injections.scm
+++ b/after/queries/python/injections.scm
@@ -7,3 +7,16 @@
  ((string) @markdown @markdown_inline)
  (#match? @markdown_inline "^[\"']{3}[%]{2}.*[%]{2}[\"']{3}$")
 )
+
+; it can be # %% [markdown] or # %% [md]
+((
+  (comment) @_mdcomment
+  . (expression_statement 
+      (string (string_content) @markdown @markdown_inline)))
+  (#lua-match? @_mdcomment "^# %%%% %[markdown%]"))
+
+((
+  (comment) @_mdcomment
+  . (expression_statement 
+      (string (string_content) @markdown @markdown_inline)))
+  (#lua-match? @_mdcomment "^# %%%% %[md%]"))

--- a/src/jupynium/buffer.py
+++ b/src/jupynium/buffer.py
@@ -134,13 +134,21 @@ class JupyniumBuffer:
         In a markdown cell, remove the leading # from the lines or multiline string.
         e.g. '# # Markdown header' -> '# Markdown header'
         """
+
+        if start_cell_idx == 0:
+            start_row_offset = 0
+        else:
+            start_row_offset = 1
+
         texts_per_cell = []
         start_row = self.get_cell_start_row(start_cell_idx)
         texts_per_cell.append(
             self._process_cell_text(
                 self.cell_types[start_cell_idx],
                 self.buf[
-                    start_row + 1 : start_row + self.num_rows_per_cell[start_cell_idx]
+                    start_row
+                    + start_row_offset : start_row
+                    + self.num_rows_per_cell[start_cell_idx]
                 ],
             )
         )

--- a/src/jupynium/cmds/ipynb2jupytext.py
+++ b/src/jupynium/cmds/ipynb2jupytext.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 import argparse
 import os
 
-from ..ipynb import ipynb2jupy, load_ipynb
+from ..ipynb import ipynb2jupytext, load_ipynb
 
 
 def get_parser():
     parser = argparse.ArgumentParser(
-        description="Convert ipynb to a jupynium file (.ju.py). Deprecated: use ipynb2jupytext instead.",
+        description="Convert ipynb to a jupytext percent format (.ju.py).",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument("ipynb_path", help="Path to ipynb file")
@@ -39,7 +39,7 @@ def main():
     check_args(args, parser)
 
     ipynb = load_ipynb(args.ipynb_path)
-    jupy = ipynb2jupy(ipynb)
+    jupy = ipynb2jupytext(ipynb)
 
     if args.stdout:
         for line in jupy:

--- a/src/jupynium/ipynb.py
+++ b/src/jupynium/ipynb.py
@@ -54,7 +54,7 @@ def cells_to_jupy(cell_types, texts):
     return jupy
 
 
-def cells_to_jupytext(cell_types, texts):
+def cells_to_jupytext(cell_types, texts, python=True):
     jupytext: list[str] = []
 
     for cell_type, text in zip(cell_types, texts):
@@ -64,18 +64,43 @@ def cells_to_jupytext(cell_types, texts):
                 if line.startswith("%"):
                     line = "# " + line
                 jupytext.append(line)
+
+            jupytext.append("")
         else:
             jupytext.append("# %% [markdown]")
-            for line in text.split("\n"):
-                jupytext.append("# " + line)
+
+            if python:
+                jupytext.append('"""')
+                for line in text.split("\n"):
+                    jupytext.append(line)
+                jupytext.append('"""')
+            else:
+                for line in text.split("\n"):
+                    jupytext.append("# " + line)
+
+            jupytext.append("")
 
     return jupytext
 
 
 def ipynb2jupy(ipynb):
+    """
+    Deprecated. Use ipynb2jupytext instead.
+    """
     cell_types, texts = read_ipynb_texts(ipynb)
     language = ipynb_language(ipynb)
     if language is None or language == "python":
         return cells_to_jupy(cell_types, texts)
     else:
         return cells_to_jupytext(cell_types, texts)
+
+
+def ipynb2jupytext(ipynb):
+    cell_types, texts = read_ipynb_texts(ipynb)
+    language = ipynb_language(ipynb)
+    if language is None or language == "python":
+        python = True
+    else:
+        python = False
+
+    return cells_to_jupytext(cell_types, texts, python)

--- a/src/jupynium/jupyter_notebook_selenium.py
+++ b/src/jupynium/jupyter_notebook_selenium.py
@@ -8,6 +8,8 @@ def insert_cell_at(driver, cell_type, cell_idx):
     Instead of insert_cell_below or insert_cell_above, it will select based on the given index.
     If cell_idx == 0, insert above, otherwise insert below.
     """
+    assert cell_type in ["code", "markdown"]
+
     if cell_idx == 0:
         logger.info(f"New {cell_type} cell created above cell 0")
         driver.execute_script(

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -15,11 +15,8 @@ def test_magic_command_1():
     """
     lines = ["a", "b", "c", "# %%", "# %time", "e", "f"]
     buffer = JupyniumBuffer(lines)
-    assert buffer.buf[4] == "%time"
-    for i, line in enumerate(lines):
-        if i == 4:
-            continue
-        assert buffer.buf[i] == line
+    code_cell_content = buffer.get_cell_text(1)
+    assert code_cell_content == "%time\ne\nf"
 
 
 def test_buffer_markdown():
@@ -37,7 +34,8 @@ def test_buffer_markdown_jupytext():
     buffer = JupyniumBuffer(["a", "b", "c", "# %% [md]", "d", "# %%", "f"])
     assert buffer.num_rows_per_cell == [3, 2, 2]
     assert buffer.cell_types == ["header", "markdown (jupytext)", "code"]
-    assert buffer.buf[4] == "d"
+    md_cell_content = buffer.get_cell_text(1)
+    assert md_cell_content == "d"
 
 
 def test_buffer_markdown_jupytext_2():
@@ -57,13 +55,35 @@ def test_buffer_markdown_jupytext_2():
     assert buffer.num_rows_per_cell == [3, 4, 2]
     assert buffer.cell_types == ["header", "markdown (jupytext)", "code"]
 
-    assert buffer.buf[0] == "a"
-    assert buffer.buf[1] == "# b"
-    assert buffer.buf[2] == "# # c"
+    header_cell_content = buffer.get_cell_text(0)
+    md_cell_content = buffer.get_cell_text(1)
+    assert header_cell_content == "a\n# b\n# # c"
+    assert md_cell_content == "# header\ncontent\nnoescape"
 
-    assert buffer.buf[4] == "# header"
-    assert buffer.buf[5] == "content"
-    assert buffer.buf[6] == "noescape"
+
+def test_buffer_markdown_jupytext_3():
+    buffer = JupyniumBuffer(
+        [
+            "a",
+            "# b",
+            "# # c",
+            "# %% [markdown]",
+            '"""',
+            "# # header",
+            "# content",
+            "noescape",
+            '"""',
+            "# %%",
+            "f",
+        ]
+    )
+    assert buffer.num_rows_per_cell == [3, 4, 2]
+    assert buffer.cell_types == ["header", "markdown (jupytext)", "code"]
+
+    header_cell_content = buffer.get_cell_text(0)
+    md_cell_content = buffer.get_cell_text(1, strip=True)
+    assert header_cell_content == "a\n# b\n# # c"
+    assert md_cell_content == "# # header\n# content\nnoescape"
 
 
 def test_buffer_markdown_jupytext_inject():
@@ -84,13 +104,10 @@ def test_buffer_markdown_jupytext_inject():
     assert buffer.num_rows_per_cell == [3, 4, 2]
     assert buffer.cell_types == ["markdown (jupytext)", "markdown (jupytext)", "code"]
 
-    assert buffer.buf[0] == "a"
-    assert buffer.buf[1] == "b"
-    assert buffer.buf[2] == "# c"
-
-    assert buffer.buf[4] == "# header"
-    assert buffer.buf[5] == "content"
-    assert buffer.buf[6] == "noescape"
+    header_cell_content = buffer.get_cell_text(0)
+    md_cell_content = buffer.get_cell_text(1)
+    assert header_cell_content == "a\nb\n# c"
+    assert md_cell_content == "# header\ncontent\nnoescape"
 
 
 def test_buffer_markdown_jupytext_inject_2():
@@ -111,13 +128,10 @@ def test_buffer_markdown_jupytext_inject_2():
     assert buffer.num_rows_per_cell == [3, 4, 2]
     assert buffer.cell_types == ["markdown", "markdown (jupytext)", "code"]
 
-    assert buffer.buf[0] == "a"
-    assert buffer.buf[1] == "# b"
-    assert buffer.buf[2] == "# # c"
-
-    assert buffer.buf[4] == "# header"
-    assert buffer.buf[5] == "content"
-    assert buffer.buf[6] == "noescape"
+    header_cell_content = buffer.get_cell_text(0)
+    md_cell_content = buffer.get_cell_text(1)
+    assert header_cell_content == "a\n# b\n# # c"
+    assert md_cell_content == "# header\ncontent\nnoescape"
 
 
 def test_buffer_markdown_jupytext_inject_3():
@@ -138,13 +152,10 @@ def test_buffer_markdown_jupytext_inject_3():
     assert buffer.num_rows_per_cell == [3, 4, 2]
     assert buffer.cell_types == ["code", "markdown (jupytext)", "code"]
 
-    assert buffer.buf[0] == "a"
-    assert buffer.buf[1] == "# b"
-    assert buffer.buf[2] == "# # c"
-
-    assert buffer.buf[4] == "# header"
-    assert buffer.buf[5] == "content"
-    assert buffer.buf[6] == "noescape"
+    header_cell_content = buffer.get_cell_text(0)
+    md_cell_content = buffer.get_cell_text(1)
+    assert header_cell_content == "a\n# b\n# # c"
+    assert md_cell_content == "# header\ncontent\nnoescape"
 
 
 def test_get_cell_start_row(jupbuf1):

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -77,7 +77,7 @@ def test_buffer_markdown_jupytext_3():
             "f",
         ]
     )
-    assert buffer.num_rows_per_cell == [3, 4, 2]
+    assert buffer.num_rows_per_cell == [3, 6, 2]
     assert buffer.cell_types == ["header", "markdown (jupytext)", "code"]
 
     header_cell_content = buffer.get_cell_text(0)


### PR DESCRIPTION
This PR adds support for Jupytext-style markdown cell with multi-line python string.

```python
# %% [md]
"""
# markdown header
markdown content
"""
```


### Implementation detail:  
- Previously, we processed the cell content as we are getting updates from neovim buffer change events.
- This PR will evaluate and manipulate the content afterwards (i.e. just before it will be sent to Jupyter Notebook)

This might have a minor performance issue, but it will be more stable to do this anyway.

This may close #64 and #44.

Additionally, this fixes #65 (creating "markdown (jupytext)" cell but it's supposed to be "markdown" cell in Notebook.)
