### PR TITLE
Add option to ipynb2jupytext to convert only code cells

### DIFF
--- a/src/jupynium/cmds/ipynb2jupytext.py
+++ b/src/jupynium/cmds/ipynb2jupytext.py
@@ -21,6 +21,9 @@ def get_parser():
     parser.add_argument(
         "-y", "--yes", action="store_true", help="Do not ask for confirmation"
     )
+    parser.add_argument(
+        "-c", "--code_only", action="store_true", help="Only convert code cells"
+    )
     parser.add_argument("-s", "--stdout", action="store_true", help="Print to stdout")
     return parser
 
@@ -39,7 +42,7 @@ def main():
     check_args(args, parser)
 
     ipynb = load_ipynb(args.ipynb_path)
-    jupy = ipynb2jupytext(ipynb)
+    jupy = ipynb2jupytext(ipynb, code_only=args.code_only)
 
     if args.stdout:
         for line in jupy:

--- a/src/jupynium/ipynb.py
+++ b/src/jupynium/ipynb.py
@@ -9,10 +9,13 @@ def load_ipynb(ipynb_path):
     return ipynb
 
 
-def read_ipynb_texts(ipynb):
+def read_ipynb_texts(ipynb, code_only=False):
     texts = []
     cell_types = []
     for cell in ipynb["cells"]:
+        if code_only:
+            if cell["cell_type"] != "code":
+                continue
         cell_types.append(cell["cell_type"])
         texts.append("".join(cell["source"]))
     return cell_types, texts
@@ -95,8 +98,8 @@ def ipynb2jupy(ipynb):
         return cells_to_jupytext(cell_types, texts)
 
 
-def ipynb2jupytext(ipynb):
-    cell_types, texts = read_ipynb_texts(ipynb)
+def ipynb2jupytext(ipynb, code_only=False):
+    cell_types, texts = read_ipynb_texts(ipynb, code_only=code_only)
     language = ipynb_language(ipynb)
     if language is None or language == "python":
         python = True


### PR DESCRIPTION

As an avid user of Colab and Kaggle, I often come across tutorial notebooks that are filled with HTML, pictures, and Markdown content. While these elements can be helpful for learning, they can also be distracting and unnecessary when I want to run the code on my own server. Additionally, I still read the notebooks on the Colab or Kaggle pages even after I've converted them to Jupytext format.

To address this issue, I propose adding an option to ipynb2jupytext that converts only the code cells to .py format. This would make it easier to work with the code on my own machine without having to sift through the extraneous content.