### PR TITLE
add option to allow user to configure floating window

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,13 @@ require("jupynium").setup({
   -- Dim all cells except the current one
   -- Related command :JupyniumShortsightedToggle
   shortsighted = false,
+
+  -- Configure floating window options
+  floating_win_opts = {
+    hover = {
+      border = "none",
+    }
+  }
 })
 
 -- You can link highlighting groups.
@@ -350,7 +357,7 @@ Any code below this line (and before the next separator) will be the content of 
   - `#%time`
 
 **Markdown cell:**
-Any code below this line will be markdown cell content.  
+Any code below this line will be markdown cell content.
 
 - `# %% [md]`
 - `# %% [markdown]`
@@ -379,7 +386,6 @@ In other languages like R, you'll need to comment every line.
   - Contents before the first cell are ignored, so use it as a heading (shebang etc.)
 - If there is no cell, it works as a markdown preview mode.
   - It will still open ipynb file but will one have one markdown cell.
-
 
 ## ⌨️ Keybindings
 

--- a/README.md
+++ b/README.md
@@ -203,8 +203,8 @@ require("jupynium").setup({
     floating_win_opts = {
       max_width = 84,
       border = "none",
-    }
-  }
+    },
+  },
 })
 
 -- You can link highlighting groups.

--- a/README.md
+++ b/README.md
@@ -199,8 +199,9 @@ require("jupynium").setup({
 
   -- Configure floating window options
   -- Related command :JupyniumKernelHover
-  floating_win_opts = {
-    hover = {
+  kernel_hover = {
+    floating_win_opts = {
+      max_width = 84,
       border = "none",
     }
   }

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ require("jupynium").setup({
   shortsighted = false,
 
   -- Configure floating window options
+  -- Related command :JupyniumKernelHover
   floating_win_opts = {
     hover = {
       border = "none",

--- a/lua/jupynium/options.lua
+++ b/lua/jupynium/options.lua
@@ -98,6 +98,7 @@ M.default_opts = {
   shortsighted = false,
 
   -- Configure floating window options
+  -- Related command :JupyniumKernelHover
   floating_win_opts = {
     hover = {
       border = "none",

--- a/lua/jupynium/options.lua
+++ b/lua/jupynium/options.lua
@@ -102,7 +102,7 @@ M.default_opts = {
   kernel_hover = {
     floating_win_opts = {
       max_width = 84,
-      border = "rounded",
+      border = "none",
     },
   },
 }

--- a/lua/jupynium/options.lua
+++ b/lua/jupynium/options.lua
@@ -99,9 +99,10 @@ M.default_opts = {
 
   -- Configure floating window options
   -- Related command :JupyniumKernelHover
-  floating_win_opts = {
-    hover = {
-      border = "none",
+  kernel_hover = {
+    floating_win_opts = {
+      max_width = 84,
+      border = "rounded",
     },
   },
 }

--- a/lua/jupynium/options.lua
+++ b/lua/jupynium/options.lua
@@ -96,6 +96,13 @@ M.default_opts = {
   -- Dim all cells except the current one
   -- Related command :JupyniumShortsightedToggle
   shortsighted = false,
+
+  -- Configure floating window options
+  floating_win_opts = {
+    hover = {
+      border = "none",
+    },
+  },
 }
 
 return M

--- a/src/jupynium/lua/helpers.lua
+++ b/src/jupynium/lua/helpers.lua
@@ -646,9 +646,14 @@ function Jupynium_kernel_hover(bufnr)
 
   local markdown_lines = vim.lsp.util.convert_input_to_markdown_lines(out)
   markdown_lines = vim.lsp.util.trim_empty_lines(markdown_lines)
-  vim.lsp.util.open_floating_preview(markdown_lines, "markdown", {
-    max_width = 84,
-  })
+
+  local opts = { max_width = 84 }
+  local ok, options = pcall(require, "jupynium.options")
+  if ok then
+    opts = vim.tbl_extend("force", opts, options.opts.floating_win_opts.hover)
+  end
+
+  vim.lsp.util.open_floating_preview(markdown_lines, "markdown", opts)
 end
 
 local function get_memory_addr(t)

--- a/src/jupynium/lua/helpers.lua
+++ b/src/jupynium/lua/helpers.lua
@@ -650,7 +650,7 @@ function Jupynium_kernel_hover(bufnr)
   local opts = { max_width = 84 }
   local ok, options = pcall(require, "jupynium.options")
   if ok then
-    opts = vim.tbl_extend("force", opts, options.opts.floating_win_opts.hover)
+    opts = vim.tbl_extend("force", opts, options.opts.kernel_hover.floating_win_opts)
   end
 
   vim.lsp.util.open_floating_preview(markdown_lines, "markdown", opts)


### PR DESCRIPTION
Allow users to configure floating win for `:JupyniumKernelHover` by passing `win_options` key in setup
```lua
require("jupynium").setup({
    win_options = {
        border = "rounded",
    },
})
```