### PR TITLE
set up keymaps when plugin is lazy loaded

### DIFF
--- a/lua/jupynium/init.lua
+++ b/lua/jupynium/init.lua
@@ -66,17 +66,15 @@ function M.setup(opts)
     server.register_autostart_autocmds(augroup, options.opts)
   end
 
+  -- Check if we need to set up keymaps in case plugin is lazy loaded like event = "BufWinEnter *.ju.*"
   local filename = vim.fn.expand "%"
   local buf_id = vim.api.nvim_get_current_buf()
-  for _, pattern in ipairs(options.opts.jupynium_file_pattern) do
-    if utils.string_wildcard_match(filename, pattern) then
-      if options.opts.use_default_keybindings then
-        M.set_default_keymaps(buf_id)
-      end
-      if options.opts.textobjects.use_default_keybindings then
-        textobj.set_default_keymaps(buf_id)
-      end
-      break
+  if utils.list_wildcard_match(filename, options.opts.jupynium_file_pattern) then
+    if options.opts.use_default_keybindings then
+      M.set_default_keymaps(buf_id)
+    end
+    if options.opts.textobjects.use_default_keybindings then
+      textobj.set_default_keymaps(buf_id)
     end
   end
 

--- a/lua/jupynium/init.lua
+++ b/lua/jupynium/init.lua
@@ -4,49 +4,48 @@ local textobj = require "jupynium.textobj"
 local highlighter = require "jupynium.highlighter"
 local server = require "jupynium.server"
 local options = require "jupynium.options"
+local utils = require "jupynium.utils"
+
+function M.set_default_keymaps(buf_id)
+  vim.keymap.set(
+    { "n", "x" },
+    "<space>x",
+    "<cmd>JupyniumExecuteSelectedCells<CR>",
+    { buffer = buf_id, desc = "Jupynium execute selected cells" }
+  )
+  vim.keymap.set(
+    { "n", "x" },
+    "<space>c",
+    "<cmd>JupyniumClearSelectedCellsOutputs<CR>",
+    { buffer = buf_id, desc = "Jupynium clear selected cells" }
+  )
+  vim.keymap.set(
+    { "n" },
+    "<space>K",
+    "<cmd>JupyniumKernelHover<cr>",
+    { buffer = buf_id, desc = "Jupynium hover (inspect a variable)" }
+  )
+  vim.keymap.set(
+    { "n", "x" },
+    "<space>js",
+    "<cmd>JupyniumScrollToCell<cr>",
+    { buffer = buf_id, desc = "Jupynium scroll to cell" }
+  )
+  vim.keymap.set(
+    { "n", "x" },
+    "<space>jo",
+    "<cmd>JupyniumToggleSelectedCellsOutputsScroll<cr>",
+    { buffer = buf_id, desc = "Jupynium toggle selected cell output scroll" }
+  )
+  vim.keymap.set("", "<PageUp>", "<cmd>JupyniumScrollUp<cr>", { buffer = buf_id, desc = "Jupynium scroll up" })
+  vim.keymap.set("", "<PageDown>", "<cmd>JupyniumScrollDown<cr>", { buffer = buf_id, desc = "Jupynium scroll down" })
+end
 
 function M.default_keybindings(augroup)
   vim.api.nvim_create_autocmd({ "BufWinEnter" }, {
     pattern = options.opts.jupynium_file_pattern,
-    callback = function()
-      local buf_id = vim.api.nvim_get_current_buf()
-      vim.keymap.set(
-        { "n", "x" },
-        "<space>x",
-        "<cmd>JupyniumExecuteSelectedCells<CR>",
-        { buffer = buf_id, desc = "Jupynium execute selected cells" }
-      )
-      vim.keymap.set(
-        { "n", "x" },
-        "<space>c",
-        "<cmd>JupyniumClearSelectedCellsOutputs<CR>",
-        { buffer = buf_id, desc = "Jupynium clear selected cells" }
-      )
-      vim.keymap.set(
-        { "n" },
-        "<space>K",
-        "<cmd>JupyniumKernelHover<cr>",
-        { buffer = buf_id, desc = "Jupynium hover (inspect a variable)" }
-      )
-      vim.keymap.set(
-        { "n", "x" },
-        "<space>js",
-        "<cmd>JupyniumScrollToCell<cr>",
-        { buffer = buf_id, desc = "Jupynium scroll to cell" }
-      )
-      vim.keymap.set(
-        { "n", "x" },
-        "<space>jo",
-        "<cmd>JupyniumToggleSelectedCellsOutputsScroll<cr>",
-        { buffer = buf_id, desc = "Jupynium toggle selected cell output scroll" }
-      )
-      vim.keymap.set("", "<PageUp>", "<cmd>JupyniumScrollUp<cr>", { buffer = buf_id, desc = "Jupynium scroll up" })
-      vim.keymap.set(
-        "",
-        "<PageDown>",
-        "<cmd>JupyniumScrollDown<cr>",
-        { buffer = buf_id, desc = "Jupynium scroll down" }
-      )
+    callback = function(event)
+      M.set_default_keymaps(event.buf)
     end,
     group = augroup,
   })
@@ -65,6 +64,20 @@ function M.setup(opts)
     or options.opts.auto_start_sync.enable
   then
     server.register_autostart_autocmds(augroup, options.opts)
+  end
+
+  local filename = vim.fn.expand "%"
+  local buf_id = vim.api.nvim_get_current_buf()
+  for _, pattern in ipairs(options.opts.jupynium_file_pattern) do
+    if utils.string_wildcard_match(filename, pattern) then
+      if options.opts.use_default_keybindings then
+        M.set_default_keymaps(buf_id)
+      end
+      if options.opts.textobjects.use_default_keybindings then
+        textobj.set_default_keymaps(buf_id)
+      end
+      break
+    end
   end
 
   if options.opts.use_default_keybindings then

--- a/lua/jupynium/textobj.lua
+++ b/lua/jupynium/textobj.lua
@@ -111,54 +111,57 @@ M.select_cell = function(include_current_separator, include_next_separator)
   select_current_cell(nil, include_current_separator, include_next_separator)
 end
 
+M.set_default_keymaps = function(buf_id)
+  vim.keymap.set(
+    { "n", "x", "o" },
+    "[j",
+    "<cmd>lua require'jupynium.textobj'.goto_previous_cell_separator()<cr>",
+    { buffer = buf_id, desc = "Go to previous Jupynium cell" }
+  )
+  vim.keymap.set(
+    { "n", "x", "o" },
+    "]j",
+    "<cmd>lua require'jupynium.textobj'.goto_next_cell_separator()<cr>",
+    { buffer = buf_id, desc = "Go to next Jupynium cell" }
+  )
+  vim.keymap.set(
+    { "n", "x", "o" },
+    "<space>jj",
+    "<cmd>lua require'jupynium.textobj'.goto_current_cell_separator()<cr>",
+    { buffer = buf_id, desc = "Go to current Jupynium cell" }
+  )
+  vim.keymap.set(
+    { "x", "o" },
+    "aj",
+    "<cmd>lua require'jupynium.textobj'.select_cell(true, false)<cr>",
+    { buffer = buf_id, desc = "Select around Jupynium cell" }
+  )
+  vim.keymap.set(
+    { "x", "o" },
+    "ij",
+    "<cmd>lua require'jupynium.textobj'.select_cell(false, false)<cr>",
+    { buffer = buf_id, desc = "Select inside Jupynium cell" }
+  )
+  vim.keymap.set(
+    { "x", "o" },
+    "aJ",
+    "<cmd>lua require'jupynium.textobj'.select_cell(true, true)<cr>",
+    { buffer = buf_id, desc = "Select around Jupynium cell (include next cell separator)" }
+  )
+  vim.keymap.set(
+    { "x", "o" },
+    "iJ",
+    "<cmd>lua require'jupynium.textobj'.select_cell(false, true)<cr>",
+    { buffer = buf_id, desc = "Select inside Jupynium cell (include next cell separator)" }
+  )
+end
+
 M.default_keybindings = function(augroup)
   -- Text objects
   vim.api.nvim_create_autocmd({ "BufWinEnter" }, {
     pattern = options.opts.jupynium_file_pattern,
-    callback = function()
-      local buf_id = vim.api.nvim_get_current_buf()
-      vim.keymap.set(
-        { "n", "x", "o" },
-        "[j",
-        "<cmd>lua require'jupynium.textobj'.goto_previous_cell_separator()<cr>",
-        { buffer = buf_id, desc = "Go to previous Jupynium cell" }
-      )
-      vim.keymap.set(
-        { "n", "x", "o" },
-        "]j",
-        "<cmd>lua require'jupynium.textobj'.goto_next_cell_separator()<cr>",
-        { buffer = buf_id, desc = "Go to next Jupynium cell" }
-      )
-      vim.keymap.set(
-        { "n", "x", "o" },
-        "<space>jj",
-        "<cmd>lua require'jupynium.textobj'.goto_current_cell_separator()<cr>",
-        { buffer = buf_id, desc = "Go to current Jupynium cell" }
-      )
-      vim.keymap.set(
-        { "x", "o" },
-        "aj",
-        "<cmd>lua require'jupynium.textobj'.select_cell(true, false)<cr>",
-        { buffer = buf_id, desc = "Select around Jupynium cell" }
-      )
-      vim.keymap.set(
-        { "x", "o" },
-        "ij",
-        "<cmd>lua require'jupynium.textobj'.select_cell(false, false)<cr>",
-        { buffer = buf_id, desc = "Select inside Jupynium cell" }
-      )
-      vim.keymap.set(
-        { "x", "o" },
-        "aJ",
-        "<cmd>lua require'jupynium.textobj'.select_cell(true, true)<cr>",
-        { buffer = buf_id, desc = "Select around Jupynium cell (include next cell separator)" }
-      )
-      vim.keymap.set(
-        { "x", "o" },
-        "iJ",
-        "<cmd>lua require'jupynium.textobj'.select_cell(false, true)<cr>",
-        { buffer = buf_id, desc = "Select inside Jupynium cell (include next cell separator)" }
-      )
+    callback = function(event)
+      M.set_default_keymaps(event.buf)
     end,
     group = augroup,
   })


### PR DESCRIPTION
Addresses #72 

Alternatively, we can skip the checks on setup and just expose the `set_default_keymaps` functions and leave it to the user to call them if they are lazy loading the plugin. Something like

```lua
return {
    "kiyoon/jupynium.nvim",
    build = "pip3 install --user .",
    event = "BufWinEnter *.ju.py",
    config = function()
        local jupynium = require("jupynium")
        jupynium.setup({})
        jupynium.set_default_keymaps()
        require("jupynium.textobjects").set_default_keymaps()
    end
}
```