### PR TITLE
feat: Connect to synchronized kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ The Jupynium server will receive events from Neovim, keep the copy of the buffer
   - Supported Python installation methods include system-level and [Conda](https://docs.conda.io/en/latest/miniconda.html)
 - 📔 Jupyter Notebook >= 6.2
   - Jupyter Lab is not supported
+  - 
+    ```sh
+    # jupyter-console is optional and used for `:JupyniumKernelOpenInTerminal`
+    pip install notebook jupyter-console
+    ```
 
 ### Install Python
 
@@ -442,6 +447,7 @@ If you want custom keymaps, add `textobjects = { use_default_keybindings = false
 :JupyniumKernelInterrupt
 :JupyniumKernelSelect
 :JupyniumKernelHover      " See value like LSP hover
+:JupyniumKernelOpenInTerminal [hostname] " Connect to kernel of synchronized notebook
 
 " Highlight
 :JupyniumShortsightedToggle

--- a/src/jupynium/events_control.py
+++ b/src/jupynium/events_control.py
@@ -524,7 +524,7 @@ def process_request_event(nvim_info: NvimInfo, driver, event):
 
     elif event[1] == "kernel_connect_info":
         driver.switch_to.window(nvim_info.window_handles[bufnr])
-        kernel_id = driver.execute_script("Jupyter.notebook.kernel.id")
+        kernel_id = driver.execute_script("return Jupyter.notebook.kernel.id")
         event[3].send(kernel_id)
         return True, None
 

--- a/src/jupynium/events_control.py
+++ b/src/jupynium/events_control.py
@@ -522,6 +522,13 @@ def process_request_event(nvim_info: NvimInfo, driver, event):
         event[3].send(ret_obj)
         return True, None
 
+    elif event[1] == "kernel_connect_info":
+        driver.switch_to.window(nvim_info.window_handles[bufnr])
+        code="return Jupyter.notebook.kernel.id"
+        ret_obj = driver.execute_script(code)
+        event[3].send(ret_obj)
+        return True, None
+
     if event[3] is not None:
         event[3].send("OK")
 

--- a/src/jupynium/events_control.py
+++ b/src/jupynium/events_control.py
@@ -524,7 +524,7 @@ def process_request_event(nvim_info: NvimInfo, driver, event):
 
     elif event[1] == "kernel_connect_info":
         driver.switch_to.window(nvim_info.window_handles[bufnr])
-        code="return Jupyter.notebook.kernel.id"
+        code = "return Jupyter.notebook.kernel.id"
         ret_obj = driver.execute_script(code)
         event[3].send(ret_obj)
         return True, None

--- a/src/jupynium/events_control.py
+++ b/src/jupynium/events_control.py
@@ -524,9 +524,8 @@ def process_request_event(nvim_info: NvimInfo, driver, event):
 
     elif event[1] == "kernel_connect_info":
         driver.switch_to.window(nvim_info.window_handles[bufnr])
-        code = "return Jupyter.notebook.kernel.id"
-        ret_obj = driver.execute_script(code)
-        event[3].send(ret_obj)
+        kernel_id = driver.execute_script("Jupyter.notebook.kernel.id")
+        event[3].send(kernel_id)
         return True, None
 
     if event[3] is not None:

--- a/src/jupynium/lua/commands.lua
+++ b/src/jupynium/lua/commands.lua
@@ -29,4 +29,4 @@ vim.api.nvim_create_user_command("JupyniumKernelRestart", "lua Jupynium_kernel_r
 vim.api.nvim_create_user_command("JupyniumKernelInterrupt", "lua Jupynium_kernel_interrupt()", {})
 vim.api.nvim_create_user_command("JupyniumKernelSelect", "lua Jupynium_kernel_select()", {})
 vim.api.nvim_create_user_command("JupyniumKernelHover", "lua Jupynium_kernel_hover()", {})
-vim.api.nvim_create_user_command("JupyniumKernelOpenInTerminal", Jupynium_connect_kernel_cmd, { nargs = "?" })
+vim.api.nvim_create_user_command("JupyniumKernelOpenInTerminal", Jupynium_kernel_connect_cmd, { nargs = "?" })

--- a/src/jupynium/lua/commands.lua
+++ b/src/jupynium/lua/commands.lua
@@ -29,3 +29,4 @@ vim.api.nvim_create_user_command("JupyniumKernelRestart", "lua Jupynium_kernel_r
 vim.api.nvim_create_user_command("JupyniumKernelInterrupt", "lua Jupynium_kernel_interrupt()", {})
 vim.api.nvim_create_user_command("JupyniumKernelSelect", "lua Jupynium_kernel_select()", {})
 vim.api.nvim_create_user_command("JupyniumKernelHover", "lua Jupynium_kernel_hover()", {})
+vim.api.nvim_create_user_command("JupyniumConnectKernel", Jupynium_connect_kernel_cmd, { nargs = "?" })

--- a/src/jupynium/lua/commands.lua
+++ b/src/jupynium/lua/commands.lua
@@ -29,4 +29,4 @@ vim.api.nvim_create_user_command("JupyniumKernelRestart", "lua Jupynium_kernel_r
 vim.api.nvim_create_user_command("JupyniumKernelInterrupt", "lua Jupynium_kernel_interrupt()", {})
 vim.api.nvim_create_user_command("JupyniumKernelSelect", "lua Jupynium_kernel_select()", {})
 vim.api.nvim_create_user_command("JupyniumKernelHover", "lua Jupynium_kernel_hover()", {})
-vim.api.nvim_create_user_command("JupyniumConnectKernel", Jupynium_connect_kernel_cmd, { nargs = "?" })
+vim.api.nvim_create_user_command("JupyniumKernelOpenInTerminal", Jupynium_connect_kernel_cmd, { nargs = "?" })

--- a/src/jupynium/lua/helpers.lua
+++ b/src/jupynium/lua/helpers.lua
@@ -689,7 +689,7 @@ function Jupynium_kernel_complete_async(bufnr, code_line, col, callback)
   Jupynium_rpcnotify("kernel_complete_async", bufnr, true, code_line, col, callback_id)
 end
 
-function Jupynium_connect_kernel(bufnr, hostname)
+function Jupynium_get_kernel_connect_shcmd(bufnr, hostname)
   if bufnr == nil or bufnr == 0 then
     bufnr = vim.api.nvim_get_current_buf()
   end
@@ -720,10 +720,10 @@ function Jupynium_connect_kernel(bufnr, hostname)
   return cmd
 end
 
-function Jupynium_connect_kernel_cmd(args)
+function Jupynium_kernel_connect_cmd(args)
   local hostname = args.args
   local buf = vim.api.nvim_get_current_buf()
-  local cmd = Jupynium_connect_kernel(buf, hostname)
+  local cmd = Jupynium_get_kernel_connect_shcmd(buf, hostname)
   vim.cmd([[split | terminal ]] .. cmd)
   vim.cmd [[normal! G]]
 end


### PR DESCRIPTION
I managed to implement an MVP for my feature request on https://github.com/kiyoon/jupynium.nvim/issues/76. The implementation follows your suggested approach:
1. start sync
1. Request the connection info by executing javascript `Jupyter.notebook.kernel.id`
2. Open a terminal and connect to it by running `jupyter console --existing`.

This implementation supports connecting to a remote kernel by explicitly passing a hostname parameter and a naive approach(`ssh host -t`), and this require https://github.com/akinsho/toggleterm.nvim as a dependency

You can view the workflow here: 

https://user-images.githubusercontent.com/41792945/231675700-e4987167-9f4d-4225-9a62-e2c9ec690d9e.mp4



 In my opinion, to improve this functionality, we may need to:
- [x] Better function name
- [x] Native terminal
- [x] Expose user configuration interfaces to modify the running command and terminal style.
- [x] Document
- [x] Check windows support

# Long-term plan

- [ ] Improve the process of connecting to a remote kernel to make it more intelligent.
- [ ] autocompletion https://github.com/jupyter/qtconsole/issues/99 https://github.com/hrsh7th/nvim-cmp/issues/1219
- [ ] Notebook 7 support https://github.com/kiyoon/jupynium.nvim/issues/74

As a beginner in JavaScript and Neovim plugin development, I would be grateful if you could share any additional ideas you may have to further improve this functionality. Additionally, I would appreciate your guidance on what else I need to do to merge this pull request. 
