### PR TITLE
feat: add function for custom folds

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Plug 'kiyoon/jupynium.nvim', { 'do': 'pip3 install --user .' }
 Plug 'hrsh7th/nvim-cmp'       " optional, for completion
 Plug 'rcarriga/nvim-notify'   " optional
 Plug 'stevearc/dressing.nvim' " optional, UI for :JupyniumKernelSelect
+Plug 'kevinhwang91/nvim-ufo'  " optional, folds for :lua require("jupynium").get_folds()
 ```
 
 With packer.nvim:
@@ -86,6 +87,7 @@ use { "kiyoon/jupynium.nvim", run = "pip3 install --user ." }
 use { "hrsh7th/nvim-cmp" }       -- optional, for completion
 use { "rcarriga/nvim-notify" }   -- optional
 use { "stevearc/dressing.nvim" } -- optional, UI for :JupyniumKernelSelect
+use { "kevinhwang91/nvim-ufo" }  -- optional, folds for :lua require("jupynium").get_folds()
 ```
 
 With 💤lazy.nvim:
@@ -100,6 +102,7 @@ With 💤lazy.nvim:
   "hrsh7th/nvim-cmp",       -- optional, for completion
   "rcarriga/nvim-notify",   -- optional
   "stevearc/dressing.nvim", -- optional, UI for :JupyniumKernelSelect
+  "kevinhwang91/nvim-ufo",  -- optional, folds for :lua require("jupynium").get_folds()
 ```
 
 #### Configure Jupynium
@@ -485,6 +488,13 @@ if status_ok then
 end
 ```
 
+There is also an API serving as a folds provider(see [#88](https://github.com/kiyoon/jupynium.nvim/pull/88) for more detail), which will return a table with format `{startLine=#num, endLine=#num}`.
+
+```lua
+require("jupynium").get_folds()
+```
+
+You should use it with a fold plugin like [nvim-ufo](https://github.com/kevinhwang91/nvim-ufo), an example is [example config](https://github.com/fecet/nvim/blob/6d8606987b73d03a7c7dc802065303b9ed09dcdb/lua/modules/configs/editor/ufo.lua).
 ## 👨‍💻️ Command-Line Usage (attach to remote Neovim)
 
 **You don't need to install the vim plugin to use Jupynium.** The plugin is responsible of adding `:JupyniumStartAndAttachToServer` etc. that just calls the command line program, plus it has textobjects and shortsighted support.

--- a/lua/jupynium/cells.lua
+++ b/lua/jupynium/cells.lua
@@ -20,6 +20,8 @@ function M.line_type(line)
     return "cell separator: code"
   elseif utils.string_begins_with(line, '%%"""') or utils.string_begins_with(line, "%%'''") then
     return "cell separator: code (string)"
+  elseif utils.string_begins_with(line, "# ---") then
+    return "metadata"
   elseif utils.string_begins_with(line, "# %") then
     return "magic command"
   elseif vim.fn.trim(line) == "" then

--- a/lua/jupynium/init.lua
+++ b/lua/jupynium/init.lua
@@ -49,7 +49,6 @@ function M.get_folds()
   if fold.startLine ~= nil and fold.startLine ~= fold.endLine then
     table.insert(res, fold)
   end
-  print(vim.inspect(res))
   return res
 end
 function M.set_default_keymaps(buf_id)

--- a/lua/jupynium/init.lua
+++ b/lua/jupynium/init.lua
@@ -5,7 +5,35 @@ local highlighter = require "jupynium.highlighter"
 local server = require "jupynium.server"
 local options = require "jupynium.options"
 local utils = require "jupynium.utils"
+local cells = require "jupynium.cells"
 
+function M.get_folds()
+  if not utils.list_wildcard_match(vim.fn.expand "%", options.opts.jupynium_file_pattern) then
+    return {}
+  end
+  local res = {}
+  local fold = {}
+
+  local line_types = cells.line_types_entire_buf()
+
+  for i, line_type in ipairs(line_types) do
+    if utils.string_begins_with(line_type, "cell separator") then
+      if vim.tbl_isempty(fold) then
+        fold.startLine = i - 1
+      else
+        fold.endLine = i - 2
+        table.insert(res, fold)
+        fold = { startLine = i - 1 }
+      end
+    end
+  end
+  fold.endLine = #line_types - 1
+  -- In case there is no cell
+  if fold.startLine ~= nil and fold.startLine ~= fold.endLine then
+    table.insert(res, fold)
+  end
+  return res
+end
 function M.set_default_keymaps(buf_id)
   vim.keymap.set(
     { "n", "x" },


### PR DESCRIPTION
I think it would be great to make cells to be foldable :eyes: 

![image](https://github.com/kiyoon/jupynium.nvim/assets/41792945/2d3c7cb4-89f9-463e-8078-c64f80071e6e)
fold:
![image](https://github.com/kiyoon/jupynium.nvim/assets/41792945/5bd10e8e-2aba-4355-bc94-edcd97e89f59)

Here is the setup for ufo(I note you also use this) https://github.com/fecet/nvim/blob/main/lua/modules/configs/editor/ufo.lua:

```lua
return function()
	local ufo = require("ufo")
	vim.o.fillchars = [[eob: ,fold: ,foldopen:,foldsep: ,foldclose:]]
	vim.o.foldcolumn = "1" -- '0' is not bad
	vim.o.foldlevel = 99 -- Using ufo provider need a large value, feel free to decrease the value
	vim.o.foldlevelstart = 99
	vim.o.foldenable = true

	local function get_cell_folds(bufnr)
		local function handleFallbackException(err, providerName)
			if type(err) == "string" and err:match("UfoFallbackException") then
				return ufo.getFolds(bufnr, providerName)
			else
				return require("promise").reject(err)
			end
		end
		return ufo.getFolds(bufnr, "lsp")
			:catch(function(err)
				return handleFallbackException(err, "treesitter")
			end)
			:catch(function(err)
				return handleFallbackException(err, "indent")
			end)
			:thenCall(function(ufo_folds)
				local ok, jupynium = pcall(require, "jupynium")
				if ok then
					for _, fold in ipairs(jupynium.get_folds()) do
						table.insert(ufo_folds, fold)
					end
				end
				return ufo_folds
			end)
	end

	local ftMap = {
		python = get_cell_folds,
	}

	ufo.setup({
		provider_selector = function(bufnr, filetype, buftype)
			return ftMap[filetype]
		end,
	})
end
```
