### PR TITLE
fix: attach stderr to jupyter process

### DIFF
--- a/src/jupynium/cmds/jupynium.py
+++ b/src/jupynium/cmds/jupynium.py
@@ -396,7 +396,9 @@ def fallback_open_notebook_server(
         jupyter_stdout = tempfile.NamedTemporaryFile()
         logger.info(f"Writing Jupyter Notebook server log to: {jupyter_stdout.name}")
         notebook_proc = subprocess.Popen(
-            jupyter_command + notebook_args, stdout=jupyter_stdout
+            jupyter_command + notebook_args,
+            stdout=jupyter_stdout,
+            stderr=subprocess.STDOUT,
         )
     except FileNotFoundError:
         # Command doesn't exist


### PR DESCRIPTION
Without stderr, kernels fail to start and JupyniumStartSync times out.

fixes #97