### PR TITLE
refactor!: remove deprecated syntax

### DIFF
--- a/after/queries/python/highlights.scm
+++ b/after/queries/python/highlights.scm
@@ -1,10 +1,5 @@
 ; extends
 
-(expression_statement
- ((string) @_var @variable)
- (#match? @_var "^[\"']{3}[%]{2}.*[%]{2}[\"']{3}$")
-)
-
 ; it can be # %% [markdown] or # %% [md]
 ((
   (comment) @_mdcomment

--- a/after/queries/python/injections.scm
+++ b/after/queries/python/injections.scm
@@ -1,13 +1,5 @@
 ; extends
 
-; match a string that starts with """%% and ends with %%"""
-; or starts with '''%% and ends with %%'''
-; and highlight it as markdown
-(expression_statement
- ((string) @markdown @markdown_inline)
- (#match? @markdown_inline "^[\"']{3}[%]{2}.*[%]{2}[\"']{3}$")
-)
-
 ; it can be # %% [markdown] or # %% [md]
 ((
   (comment) @_mdcomment

--- a/lua/jupynium/cells.lua
+++ b/lua/jupynium/cells.lua
@@ -1,5 +1,3 @@
-local utils = require "jupynium.utils"
-
 local M = {}
 
 --- Get the line type (cell separator, magic commands, empty, others)
@@ -14,9 +12,9 @@ function M.line_type(line)
     return "cell separator: markdown"
   elseif vim.fn.trim(line) == "# %%" then
     return "cell separator: code"
-  elseif utils.string_begins_with(line, "# ---") then
+  elseif vim.startswith(line, "# ---") then
     return "metadata"
-  elseif utils.string_begins_with(line, "# %") then
+  elseif vim.startswith(line, "# %") then
     return "magic command"
   elseif vim.fn.trim(line) == "" then
     return "empty"
@@ -72,7 +70,7 @@ end
 ---@return boolean
 function M.is_line_separator(line)
   local line_type = M.line_type(line)
-  if utils.string_begins_with(line_type, "cell separator:") then
+  if vim.startswith(line_type, "cell separator:") then
     return true
   end
 

--- a/lua/jupynium/init.lua
+++ b/lua/jupynium/init.lua
@@ -18,7 +18,7 @@ function M.get_folds()
   local line_types = cells.line_types_entire_buf()
 
   for i, line_type in ipairs(line_types) do
-    if utils.string_begins_with(line_type, "metadata") then
+    if vim.startswith(line_type, "metadata") then
       -- make sure metadata is before cells
       if vim.tbl_isempty(fold) then
         if vim.tbl_isempty(metadata) then
@@ -29,7 +29,7 @@ function M.get_folds()
         end
       end
     end
-    if utils.string_begins_with(line_type, "cell separator") then
+    if vim.startswith(line_type, "cell separator") then
       if vim.tbl_isempty(fold) then
         fold.startLine = i - 1
         -- close metadata

--- a/lua/jupynium/server.lua
+++ b/lua/jupynium/server.lua
@@ -40,7 +40,7 @@ local function get_system_cmd(cmd, args)
   if vim.fn.has "win32" == 1 then
     -- powershell.exe for powershell <= 5
     -- pwsh.exe for powershell >= 6
-    if utils.string_begins_with(vim.o.shell, "powershell") or utils.string_begins_with(vim.o.shell, "pwsh") then
+    if vim.startswith(vim.o.shell, "powershell") or vim.startswith(vim.o.shell, "pwsh") then
       cmd_str = [[& ']] .. vim.fn.expand(cmd) .. [[']]
       for _, v in ipairs(args) do
         cmd_str = cmd_str .. [[ ']] .. v .. [[']]

--- a/lua/jupynium/utils.lua
+++ b/lua/jupynium/utils.lua
@@ -1,25 +1,11 @@
 local M = {}
 
-function M.string_begins_with(str, start)
-  if str == nil then
-    return false
-  end
-  return start == "" or str:sub(1, #start) == start
-end
-
-function M.string_ends_with(str, ending)
-  if str == nil then
-    return false
-  end
-  return ending == "" or str:sub(-#ending) == ending
-end
-
 function M.wildcard_to_regex(pattern)
   local reg = pattern:gsub("([^%w])", "%%%1"):gsub("%%%*", ".*")
-  if not M.string_begins_with(reg, ".*") then
+  if not vim.startswith(reg, ".*") then
     reg = "^" .. reg
   end
-  if not M.string_ends_with(reg, ".*") then
+  if not vim.endswith(reg, ".*") then
     reg = reg .. "$"
   end
   return reg


### PR DESCRIPTION
- Remove deprecated old markdown syntax (`"""%% .. %%"""`)
- `utils.string_begins_with()` -> `vim.startswith()`