### PR TITLE
refactor!: remove deprecated commands

### DIFF
--- a/src/jupynium/lua/commands.lua
+++ b/src/jupynium/lua/commands.lua
@@ -21,10 +21,6 @@ vim.api.nvim_create_user_command("JupyniumScrollUp", "lua Jupynium_scroll_up()",
 vim.api.nvim_create_user_command("JupyniumScrollDown", "lua Jupynium_scroll_down()", {})
 vim.api.nvim_create_user_command("JupyniumAutoscrollToggle", "lua Jupynium_autoscroll_toggle()", {})
 
----@deprecated
-vim.api.nvim_create_user_command("JupyniumRestartKernel", "lua Jupynium_restart_kernel()", {})
-vim.api.nvim_create_user_command("JupyniumSelectKernel", "lua Jupynium_select_kernel()", {})
-
 vim.api.nvim_create_user_command("JupyniumKernelRestart", "lua Jupynium_kernel_restart()", {})
 vim.api.nvim_create_user_command("JupyniumKernelInterrupt", "lua Jupynium_kernel_interrupt()", {})
 vim.api.nvim_create_user_command("JupyniumKernelSelect", "lua Jupynium_kernel_select()", {})

--- a/src/jupynium/lua/helpers.lua
+++ b/src/jupynium/lua/helpers.lua
@@ -487,11 +487,6 @@ function Jupynium_kernel_change(bufnr, kernel_name)
   Jupynium_rpcnotify("kernel_change", bufnr, true, kernel_name)
 end
 
-function Jupynium_restart_kernel(bufnr)
-  Jupynium_notify.warn { [[Sorry! Command name changed.]], [[Please use :JupyniumKernelRestart]] }
-  return Jupynium_kernel_restart(bufnr)
-end
-
 function Jupynium_kernel_restart(bufnr)
   -- note that the kernel name is different from the display name in the kernel list in Jupyter Notebook.
   if bufnr == nil or bufnr == 0 then
@@ -517,11 +512,6 @@ function Jupynium_kernel_interrupt(bufnr)
   end
 
   Jupynium_rpcnotify("kernel_interrupt", bufnr, true)
-end
-
-function Jupynium_select_kernel(bufnr)
-  Jupynium_notify.warn { [[Sorry! Command name changed.]], [[Please use :JupyniumKernelSelect]] }
-  return Jupynium_kernel_select(bufnr)
 end
 
 function Jupynium_kernel_select(bufnr)


### PR DESCRIPTION
Removed following commands:

- `:JupyniumRestartKernel`
- `:JupyniumSelectKernel`
- `Jupynium_restart_kernel`
- `Jupynium_select_kernel`