### PR TITLE
fix: error in empty ipynb and default kernel not existing

### DIFF
--- a/lua/jupynium/cells.lua
+++ b/lua/jupynium/cells.lua
@@ -8,7 +8,9 @@ function M.line_type(line)
     line = vim.api.nvim_buf_get_lines(0, line - 1, line, false)[1]
   end
 
-  if vim.startswith(line, "# %% [md]") or vim.startswith(line, "# %% [markdown]") then
+  if line == nil then
+    return "empty"
+  elseif vim.startswith(line, "# %% [md]") or vim.startswith(line, "# %% [markdown]") then
     return "cell separator: markdown"
   elseif vim.fn.trim(line) == "# %%" then
     return "cell separator: code"


### PR DESCRIPTION
Fixes #123 and more.

1. Fix error when opening an empty .ju.py buffer.
2. Fix error when there is no default system python3 kernel. It happened to me when I installed `conda install nb_conda_kernels`