### PR TITLE
Enhance Parser to Support # %% with Additional Comments

### DIFF
--- a/lua/jupynium/cells.lua
+++ b/lua/jupynium/cells.lua
@@ -12,6 +12,9 @@ function M.line_type(line)
     return "empty"
   elseif vim.startswith(line, "# %% [md]") or vim.startswith(line, "# %% [markdown]") then
     return "cell separator: markdown"
+  -- Treat '# %% Cell Title' as a code cell
+  -- But not magic commands such as '# %%timeit'.
+  -- See: https://github.com/kiyoon/jupynium.nvim/pull/127
   elseif vim.fn.trim(string.sub(line, 1, 5)) == "# %%" then
     return "cell separator: code"
   elseif vim.startswith(line, "# ---") then

--- a/lua/jupynium/cells.lua
+++ b/lua/jupynium/cells.lua
@@ -12,7 +12,7 @@ function M.line_type(line)
     return "empty"
   elseif vim.startswith(line, "# %% [md]") or vim.startswith(line, "# %% [markdown]") then
     return "cell separator: markdown"
-  elseif vim.fn.trim(line) == "# %%" then
+  elseif vim.fn.trim(string.sub(line, 1, 5)) == "# %%" then
     return "cell separator: code"
   elseif vim.startswith(line, "# ---") then
     return "metadata"

--- a/src/jupynium/buffer.py
+++ b/src/jupynium/buffer.py
@@ -75,7 +75,7 @@ class JupyniumBuffer:
                 num_rows_per_cell.append(num_rows_this_cell)
                 num_rows_this_cell = 1
                 cell_types.append("markdown")
-            elif line.startswith("# %%"):
+            elif line[:5].strip() == "# %%":
                 num_rows_per_cell.append(num_rows_this_cell)
                 num_rows_this_cell = 1
                 cell_types.append("code")

--- a/src/jupynium/buffer.py
+++ b/src/jupynium/buffer.py
@@ -75,6 +75,9 @@ class JupyniumBuffer:
                 num_rows_per_cell.append(num_rows_this_cell)
                 num_rows_this_cell = 1
                 cell_types.append("markdown")
+            # Treat '# %% Cell Title' as a code cell
+            # But not magic commands such as '# %%timeit'.
+            # See: https://github.com/kiyoon/jupynium.nvim/pull/127
             elif line[:5].strip() == "# %%":
                 num_rows_per_cell.append(num_rows_this_cell)
                 num_rows_this_cell = 1

--- a/src/jupynium/buffer.py
+++ b/src/jupynium/buffer.py
@@ -71,11 +71,11 @@ class JupyniumBuffer:
         num_rows_per_cell = []
         cell_types = [header_cell_type]
         for _row, line in enumerate(self.buf):
-            if line.startswith(("# %% [md]", "# %% [markdown]")):
+            if re.match(r"^# %% \[md\]", line) or re.match(r"^# %% \[markdown\]", line):
                 num_rows_per_cell.append(num_rows_this_cell)
                 num_rows_this_cell = 1
                 cell_types.append("markdown")
-            elif line.strip() == "# %%":
+            elif re.match(r"^# %%.*", line):
                 num_rows_per_cell.append(num_rows_this_cell)
                 num_rows_this_cell = 1
                 cell_types.append("code")

--- a/src/jupynium/buffer.py
+++ b/src/jupynium/buffer.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import re
 
 from pkg_resources import resource_stream
 from selenium.webdriver.remote.webdriver import WebDriver
@@ -72,11 +71,11 @@ class JupyniumBuffer:
         num_rows_per_cell = []
         cell_types = [header_cell_type]
         for _row, line in enumerate(self.buf):
-            if re.match(r"^# %% \[md\]", line) or re.match(r"^# %% \[markdown\]", line):
+            if line.startswith(("# %% [md]", "# %% [markdown]")):
                 num_rows_per_cell.append(num_rows_this_cell)
                 num_rows_this_cell = 1
                 cell_types.append("markdown")
-            elif re.match(r"^# %%.*", line):
+            elif line.startswith("# %%"):
                 num_rows_per_cell.append(num_rows_this_cell)
                 num_rows_this_cell = 1
                 cell_types.append("code")

--- a/src/jupynium/buffer.py
+++ b/src/jupynium/buffer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import re
 
 from pkg_resources import resource_stream
 from selenium.webdriver.remote.webdriver import WebDriver

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -11,6 +11,12 @@ def test_buffer_1():
     assert buffer.cell_types == ["header", "code"]
 
 
+def test_buffer_with_cell_title_1():
+    buffer = JupyniumBuffer(["a", "b", "c", "# %% Cell Title", "d", "e", "f"])
+    assert buffer.num_rows_per_cell == [3, 4]
+    assert buffer.cell_types == ["header", "code"]
+
+
 def test_magic_command_1():
     """
     Everything else except magic commands should be preserved after __init__() or fully_analysed_buf().
@@ -19,6 +25,16 @@ def test_magic_command_1():
     buffer = JupyniumBuffer(lines)
     code_cell_content = buffer.get_cell_text(1)
     assert code_cell_content == "%time\ne\nf"
+
+
+def test_double_magic_command_1():
+    """
+    Everything else except double magic commands should be preserved after __init__() or fully_analyse_buf().
+    """
+    lines = ["a", "b", "c", "# %% Cell Title", "# %%timeit", "e", "f"]
+    buffer = JupyniumBuffer(lines)
+    code_cell_content = buffer.get_cell_text(1)
+    assert code_cell_content == "%%timeit\ne\nf"
 
 
 def test_buffer_markdown():


### PR DESCRIPTION
### Summary

This pull request enhances the parser to correctly recognize lines that start with `# %%`, even when followed by additional comments ~~or markdown annotations~~. This improvement is achieved by using regular expressions.

### Detailed Description

- **Enhancement**: Refactored the parser to use regex for identifying cells that start with `# %%` and may include additional comments or markdown annotations.

### Changes

- Added regex-based identification of cells to the parser.
- Imported the `re` module to facilitate regex matching.

### Motivation

The existing parser did not handle lines starting with `# %%` when followed by additional comments or markdown annotations. By using regular expressions, the parser can now accurately identify such lines, improving its robustness and flexibility.

### Testing

- Verified that the parser correctly identifies cells starting with `# %%` followed by additional comments or markdown annotations.
- Ensured no existing functionality is broken by these changes.


Thank you for considering this pull request. I look forward to your feedback.