### PR TITLE
fix: custom firefox profile

### DIFF
--- a/src/jupynium/cmds/jupynium.py
+++ b/src/jupynium/cmds/jupynium.py
@@ -103,7 +103,8 @@ def webdriver_firefox(
     logger.info(f"Using firefox profile: {profile_path}")
 
     options = Options()
-    options.profile = webdriver.FirefoxProfile(profile_path)
+    options.add_argument("-profile")
+    options.add_argument(str(profile_path))
     options.set_preference("browser.link.open_newwindow", 3)
     options.set_preference("browser.link.open_newwindow.restriction", 0)
     # profile.setAlwaysLoadNoFocusLib(True);


### PR DESCRIPTION
Selenium's way of passing a user profile to Firefox has changed some time ago (current - [here](https://www.selenium.dev/documentation/webdriver/browsers/firefox/)), so Jupynium currently ignores the supplied profile. This PR updates the relevant Options method.