### PR TITLE
feat: scroll to output

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,9 +187,11 @@ require("jupynium").setup({
 
   -- Always scroll to the current cell.
   -- Related command :JupyniumScrollToCell
+  -- Related command :JupyniumScrollToOutput
   autoscroll = {
     enable = true,
     mode = "always", -- "always" or "invisible"
+    focus = "input", -- "input" or "output"
     cell = {
       top_margin_percent = 20,
     },
@@ -462,6 +464,7 @@ In other languages like R, you'll need to comment every line.
 - `<space>c`: Clear selected cells
 - `<PageUp>`, `<PageDown>`: Scroll notebook
 - `<space>js`: Scroll to cell (if autoscroll is disabled)
+- `<space>os`: Scroll to output (if autoscroll is disabled)
 - `<space>K`: Hover (inspect a variable)
 - `<space>jo`: Toggle output scroll (when output is long)
 
@@ -499,6 +502,7 @@ If you want custom keymaps, add `textobjects = { use_default_keybindings = false
 :JupyniumAutoDownloadIpynbToggle
 
 :JupyniumScrollToCell
+:JupyniumScrollToOutput
 :JupyniumScrollUp
 :JupyniumScrollDown
 :JupyniumAutoscrollToggle

--- a/lua/jupynium/init.lua
+++ b/lua/jupynium/init.lua
@@ -78,6 +78,12 @@ function M.set_default_keymaps(buf_id)
   )
   vim.keymap.set(
     { "n", "x" },
+    "<space>os",
+    "<cmd>JupyniumScrollToOutput<cr>",
+    { buffer = buf_id, desc = "Jupynium scroll to output" }
+  )
+  vim.keymap.set(
+    { "n", "x" },
     "<space>jo",
     "<cmd>JupyniumToggleSelectedCellsOutputsScroll<cr>",
     { buffer = buf_id, desc = "Jupynium toggle selected cell output scroll" }
@@ -128,6 +134,7 @@ function M.setup(opts)
   vim.g.jupynium_scroll_cell_top_margin_percent = options.opts.scroll.cell.top_margin_percent
   vim.g.jupynium_autoscroll_enable = options.opts.autoscroll.enable
   vim.g.jupynium_autoscroll_mode = options.opts.autoscroll.mode
+  vim.g.jupynium_autoscroll_focus = options.opts.autoscroll.focus
   vim.g.jupynium_autoscroll_cell_top_margin_percent = options.opts.autoscroll.cell.top_margin_percent
 
   if options.opts.textobjects.use_default_keybindings then

--- a/lua/jupynium/options.lua
+++ b/lua/jupynium/options.lua
@@ -18,6 +18,7 @@
 ---@class (exact) Jupynium.Config.Autoscroll
 ---@field enable boolean
 ---@field mode string
+---@field focus string
 ---@field cell Jupynium.Config.Scroll.Cell
 
 ---@class (exact) Jupynium.Config.Scroll.Page
@@ -198,11 +199,13 @@ M.default_opts = {
   -- Automatically close tab that is in sync when you close buffer in vim.
   auto_close_tab = true,
 
-  -- Always scroll to the current cell.
+  -- Always scroll to the current cell (output).
   -- Related command :JupyniumScrollToCell
+  -- Related command :JupyniumScrollToOutput
   autoscroll = {
     enable = true,
     mode = "always", -- "always" or "invisible"
+    focus = "input", -- "input" or "output"
     cell = {
       top_margin_percent = 20,
     },

--- a/src/jupynium/events_control.py
+++ b/src/jupynium/events_control.py
@@ -436,7 +436,9 @@ def choose_default_kernel(  # noqa: PLR0911
     return None
 
 
-def process_request_event(nvim_info: NvimInfo, driver: WebDriver, event: Request):  # noqa: PLR0911
+def process_request_event(
+    nvim_info: NvimInfo, driver: WebDriver, event: Request
+):  # noqa: PLR0911
     """
     Process a request event, where an event can be request or notification.
 
@@ -550,7 +552,7 @@ def process_request_event(nvim_info: NvimInfo, driver: WebDriver, event: Request
         return True, None
 
     elif event.name == "kernel_inspect":
-        (line, col) = event_args
+        line, col = event_args
         driver.switch_to.window(nvim_info.window_handles[bufnr])
         inspect_result = driver.execute_async_script(kernel_inspect_js_code, line, col)
         logger.info(f"Kernel inspect: {inspect_result}")
@@ -716,7 +718,7 @@ def process_notification_event(  # noqa: C901 PLR0912 PLR0915
                         f"{output_ipynb_path} is not accessible on the local machine."
                     )
         elif event.name == "download_ipynb":
-            (buf_filepath, filename) = event_args
+            buf_filepath, filename = event_args
             assert buf_filepath != ""
 
             buf_filepath = Path(buf_filepath)
@@ -776,7 +778,7 @@ def process_notification_event(  # noqa: C901 PLR0912 PLR0915
                 "Jupyter.kernelselector.set_kernel(arguments[0])", kernel_name
             )
         elif event.name == "kernel_complete_async":
-            (line, col, callback_id, completion_plugin) = event_args
+            line, col, callback_id, completion_plugin = event_args
             if (
                 nvim_info.nvim.vars["jupynium_kernel_complete_async_callback_id"]
                 != callback_id
@@ -854,6 +856,10 @@ def process_notification_event(  # noqa: C901 PLR0912 PLR0915
         elif event.name == "scroll_to_cell":
             (cursor_pos_row,) = event_args
             scroll_to_cell(driver, nvim_info, bufnr, cursor_pos_row)
+
+        elif event.name == "scroll_to_output":
+            (cursor_pos_row,) = event_args
+            scroll_to_output(driver, nvim_info, bufnr, cursor_pos_row)
 
         elif event.name == "grab_entire_buf":
             # Refresh entire buffer from nvim
@@ -937,34 +943,24 @@ def update_cell_selection(
             update_cell_selection_js_code, cell_index, cell_index_visual
         )
 
-        if selection_updated:
-            autoscroll_enable = nvim_info.nvim.vars.get(
-                "jupynium_autoscroll_enable", True
-            )
-            if autoscroll_enable:
-                autoscroll_mode = nvim_info.nvim.vars.get(
-                    "jupynium_autoscroll_mode", "always"
+        autoscroll_enable = nvim_info.nvim.vars.get("jupynium_autoscroll_enable", True)
+        autoscroll_mode = nvim_info.nvim.vars.get("jupynium_autoscroll_mode", "always")
+        autoscroll_focus = nvim_info.nvim.vars.get("jupynium_autoscroll_focus", "input")
+        if selection_updated and autoscroll_enable:
+            if autoscroll_mode == "always":
+                do_scroll = True
+            else:
+                do_scroll = not driver.execute_script(
+                    "return Jupyter.notebook.scroll_manager.is_cell_visible"
+                    "(Jupyter.notebook.get_cell(arguments[0]));",
+                    cell_index,
                 )
 
-                if autoscroll_mode == "always":
-                    do_scroll = True
-                else:
-                    do_scroll = not driver.execute_script(
-                        "return Jupyter.notebook.scroll_manager.is_cell_visible"
-                        "(Jupyter.notebook.get_cell(arguments[0]));",
-                        cell_index,
-                    )
-
-                if do_scroll:
-                    # scroll to cell
-                    top_margin_percent = nvim_info.nvim.vars.get(
-                        "jupynium_autoscroll_cell_top_margin_percent", 0
-                    )
-                    driver.execute_script(
-                        "Jupyter.notebook.scroll_cell_percent(arguments[0], arguments[1], 0);",
-                        cell_index,
-                        top_margin_percent,
-                    )
+            if do_scroll:
+                if autoscroll_focus == "input":
+                    scroll_to_cell(driver, nvim_info, bufnr, cursor_pos_row)
+                elif autoscroll_focus == "output":
+                    scroll_to_output(driver, nvim_info, bufnr, cursor_pos_row)
 
 
 def download_ipynb(
@@ -1007,4 +1003,20 @@ def scroll_to_cell(driver: WebDriver, nvim_info: NvimInfo, bufnr: int, cursor_po
         "Jupyter.notebook.scroll_cell_percent(arguments[0], arguments[1], 0);",
         cell_index,
         top_margin_percent,
+    )
+
+
+def scroll_to_output(
+    driver: WebDriver, nvim_info: NvimInfo, bufnr: int, cursor_pos_row
+):
+    # Which cell?
+    cell_index, _, _ = nvim_info.jupbufs[bufnr].get_cell_index_from_row(cursor_pos_row)
+
+    cell_index = max(cell_index - 1, 0)
+
+    driver.switch_to.window(nvim_info.window_handles[bufnr])
+
+    driver.execute_script(
+        "Jupyter.notebook.get_cell_element(arguments[0])[0].children[1].scrollIntoView({block: 'center'});",
+        cell_index,
     )

--- a/src/jupynium/events_control.py
+++ b/src/jupynium/events_control.py
@@ -436,9 +436,7 @@ def choose_default_kernel(  # noqa: PLR0911
     return None
 
 
-def process_request_event(
-    nvim_info: NvimInfo, driver: WebDriver, event: Request
-):  # noqa: PLR0911
+def process_request_event(nvim_info: NvimInfo, driver: WebDriver, event: Request):  # noqa: PLR0911
     """
     Process a request event, where an event can be request or notification.
 

--- a/src/jupynium/lua/commands.lua
+++ b/src/jupynium/lua/commands.lua
@@ -14,6 +14,7 @@ vim.api.nvim_create_user_command(
   {}
 )
 vim.api.nvim_create_user_command("JupyniumScrollToCell", "lua Jupynium_scroll_to_cell()", {})
+vim.api.nvim_create_user_command("JupyniumScrollToOutput", "lua Jupynium_scroll_to_output()", {})
 vim.api.nvim_create_user_command("JupyniumSaveIpynb", "lua Jupynium_save_ipynb()", {})
 vim.api.nvim_create_user_command("JupyniumDownloadIpynb", Jupynium_download_ipynb_cmd, { nargs = "?" })
 vim.api.nvim_create_user_command("JupyniumAutoDownloadIpynbToggle", "lua Jupynium_auto_download_ipynb_toggle()", {})

--- a/src/jupynium/lua/helpers.lua
+++ b/src/jupynium/lua/helpers.lua
@@ -372,6 +372,20 @@ function Jupynium_scroll_to_cell(bufnr)
   Jupynium_rpcnotify("scroll_to_cell", bufnr, true, cursor_pos[1] - 1)
 end
 
+function Jupynium_scroll_to_output(bufnr)
+  if bufnr == nil or bufnr == 0 then
+    bufnr = vim.api.nvim_get_current_buf()
+  end
+  if Jupynium_syncing_bufs[bufnr] == nil then
+    Jupynium_notify.error { [[Cannot scroll to output without synchronising.]], [[Run `:JupyniumStartSync`]] }
+    return
+  end
+
+  local winid = vim.call("bufwinid", bufnr)
+  local cursor_pos = vim.api.nvim_win_get_cursor(winid)
+  Jupynium_rpcnotify("scroll_to_output", bufnr, true, cursor_pos[1] - 1)
+end
+
 function Jupynium_save_ipynb(bufnr)
   if bufnr == nil or bufnr == 0 then
     bufnr = vim.api.nvim_get_current_buf()

--- a/src/jupynium/selenium_helpers.py
+++ b/src/jupynium/selenium_helpers.py
@@ -27,8 +27,9 @@ def wait_until_notebook_loaded(driver: WebDriver, timeout: int = 30):
     try:
         WebDriverWait(driver, timeout).until(
             # Sometimes if kernel is null, it will hang, so we check that.
-            lambda d: d.execute_script("return Jupyter.notebook.kernel == null")
-            is False
+            lambda d: (
+                d.execute_script("return Jupyter.notebook.kernel == null") is False
+            )
         )
     except TimeoutException:
         logger.exception("Timed out waiting for kernel to load (null)")
@@ -37,8 +38,10 @@ def wait_until_notebook_loaded(driver: WebDriver, timeout: int = 30):
     try:
         WebDriverWait(driver, timeout).until(
             # Sometimes if kernel is null, it will hang, so we check that.
-            lambda d: d.execute_script("return Jupyter.notebook.kernel.is_connected()")
-            is True
+            lambda d: (
+                d.execute_script("return Jupyter.notebook.kernel.is_connected()")
+                is True
+            )
         )
     except TimeoutException:
         logger.exception("Timed out waiting for kernel to load")


### PR DESCRIPTION
Often times I find it inconvenient the autoscroll only focus on the cell input (which I already know because I'm typing that in neovim), the output might not be visible if input is long. So I decided to add this small feature

- Added a nvim user command `JupyniumScrollToOutput` to manually scroll to cell output
- Added an option `autoscroll.focus` to determine what to focus on when using auto scroll
- Updated README 